### PR TITLE
Sort/truncate audit log, include number of deleted tags in tag_cleanup

### DIFF
--- a/api/db/audit-log-queries.test.ts
+++ b/api/db/audit-log-queries.test.ts
@@ -9,7 +9,7 @@ const bungieMembershipId = 1234;
 beforeEach(async () => {
   await pool.query({
     text: 'delete from audit_log where membership_id = $1',
-    values: [bungieMembershipId]
+    values: [bungieMembershipId],
   });
 });
 
@@ -21,8 +21,10 @@ it('can insert audit logs', async () => {
       type: 'tag_cleanup',
       platformMembershipId,
       destinyVersion: 2,
-      payload: {},
-      createdBy: appId
+      payload: {
+        deleted: 1,
+      },
+      createdBy: appId,
     };
     await recordAuditLog(client, bungieMembershipId, entry);
 

--- a/api/db/audit-log-queries.ts
+++ b/api/db/audit-log-queries.ts
@@ -11,8 +11,8 @@ export async function getAuditLog(
   const results = await client.query({
     name: 'get_audit_log',
     text:
-      'SELECT platform_membership_id, destiny_version, type, entry, created_at, created_by FROM audit_log WHERE membership_id = $1 ORDER BY created_by, id desc',
-    values: [bungieMembershipId]
+      'SELECT platform_membership_id, destiny_version, type, entry, created_at, created_by FROM audit_log WHERE membership_id = $1 ORDER BY created_at, id desc LIMIT 100',
+    values: [bungieMembershipId],
   });
   return results.rows.map(convertAuditLog);
 }
@@ -24,7 +24,7 @@ function convertAuditLog(row: any): AuditLogEntry {
     type: row.type,
     payload: row.entry,
     createdAt: row.created_at.getTime(),
-    createdBy: row.created_by
+    createdBy: row.created_by,
   };
   return entry;
 }
@@ -47,8 +47,8 @@ values ($1, $2, $3, $4, $5, $6)`,
       entry.destinyVersion || 2,
       entry.type,
       entry.payload,
-      entry.createdBy
-    ]
+      entry.createdBy,
+    ],
   });
 
   return response;

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -9,11 +9,11 @@ import { Loadout } from '../shapes/loadouts';
 import { setSetting as setSettingInDb } from '../db/settings-queries';
 import {
   updateLoadout as updateLoadoutInDb,
-  deleteLoadout as deleteLoadoutInDb
+  deleteLoadout as deleteLoadoutInDb,
 } from '../db/loadouts-queries';
 import {
   updateItemAnnotation as updateItemAnnotationInDb,
-  deleteItemAnnotationList
+  deleteItemAnnotationList,
 } from '../db/item-annotations-queries';
 import { ItemAnnotation } from '../shapes/item-annotations';
 import { metrics } from '../metrics';
@@ -103,7 +103,7 @@ export const updateHandler = asyncHandler(async (req, res) => {
   });
 
   res.send({
-    results
+    results,
   });
 });
 
@@ -120,7 +120,7 @@ async function updateSetting(
   await recordAuditLog(client, bungieMembershipId, {
     type: 'settings',
     payload: settings,
-    createdBy: appId
+    createdBy: appId,
   });
 
   return { status: 'Success' };
@@ -138,7 +138,7 @@ async function updateLoadout(
     metrics.increment('update.validation.platformMembershipIdMissing.count');
     return {
       status: 'InvalidArgument',
-      message: 'Loadouts require platform membership ID to be set'
+      message: 'Loadouts require platform membership ID to be set',
     };
   }
 
@@ -146,14 +146,14 @@ async function updateLoadout(
     metrics.increment('update.validation.loadoutNameMissing.count');
     return {
       status: 'InvalidArgument',
-      message: 'Loadout name missing'
+      message: 'Loadout name missing',
     };
   }
   if (loadout.name && loadout.name.length > 120) {
     metrics.increment('update.validation.loadoutNameTooLong.count');
     return {
       status: 'InvalidArgument',
-      message: 'Loadout names must be under 120 characters'
+      message: 'Loadout names must be under 120 characters',
     };
   }
 
@@ -161,14 +161,14 @@ async function updateLoadout(
     metrics.increment('update.loadoutIdMissing.count');
     return {
       status: 'InvalidArgument',
-      message: 'Loadout id missing'
+      message: 'Loadout id missing',
     };
   }
   if (loadout.id && loadout.id.length > 120) {
     metrics.increment('update.validation.loadoutIdTooLong.count');
     return {
       status: 'InvalidArgument',
-      message: 'Loadout ids must be under 120 characters'
+      message: 'Loadout ids must be under 120 characters',
     };
   }
 
@@ -176,14 +176,14 @@ async function updateLoadout(
     metrics.increment('update.validation.classTypeMissing.count');
     return {
       status: 'InvalidArgument',
-      message: 'Loadout class type missing or malformed'
+      message: 'Loadout class type missing or malformed',
     };
   }
   if (loadout.classType < 0 || loadout.classType > 3) {
     metrics.increment('update.validation.classTypeOutOfRange.count');
     return {
       status: 'InvalidArgument',
-      message: 'Loadout class type out of range'
+      message: 'Loadout class type out of range',
     };
   }
 
@@ -201,9 +201,9 @@ async function updateLoadout(
     platformMembershipId,
     destinyVersion,
     payload: {
-      name: loadout.name
+      name: loadout.name,
     },
-    createdBy: appId
+    createdBy: appId,
   });
 
   return { status: 'Success' };
@@ -231,9 +231,9 @@ async function deleteLoadout(
     platformMembershipId,
     destinyVersion,
     payload: {
-      name: loadout.name
+      name: loadout.name,
     },
-    createdBy: appId
+    createdBy: appId,
   });
 
   return { status: 'Success' };
@@ -251,7 +251,7 @@ async function updateItemAnnotation(
     metrics.increment('update.validation.platformMembershipIdMissing.count');
     return {
       status: 'InvalidArgument',
-      message: 'Tags require platform membership ID to be set'
+      message: 'Tags require platform membership ID to be set',
     };
   }
 
@@ -264,14 +264,14 @@ async function updateItemAnnotation(
     metrics.increment('update.validation.tagNotRecognized.count');
     return {
       status: 'InvalidArgument',
-      message: `Tag value ${itemAnnotation.tag} is not recognized`
+      message: `Tag value ${itemAnnotation.tag} is not recognized`,
     };
   }
   if (itemAnnotation.notes && itemAnnotation.notes.length > 1024) {
     metrics.increment('update.validation.notesTooLong.count');
     return {
       status: 'InvalidArgument',
-      message: 'Notes must be under 1024 characters'
+      message: 'Notes must be under 1024 characters',
     };
   }
 
@@ -289,7 +289,7 @@ async function updateItemAnnotation(
     platformMembershipId,
     destinyVersion,
     payload: itemAnnotation,
-    createdBy: appId
+    createdBy: appId,
   });
 
   return { status: 'Success' };
@@ -303,14 +303,20 @@ async function tagCleanup(
   destinyVersion: DestinyVersion,
   inventoryItemIds: string[]
 ): Promise<ProfileUpdateResult> {
-  await deleteItemAnnotationList(client, bungieMembershipId, inventoryItemIds);
+  const result = await deleteItemAnnotationList(
+    client,
+    bungieMembershipId,
+    inventoryItemIds
+  );
 
   await recordAuditLog(client, bungieMembershipId, {
     type: 'tag_cleanup',
     platformMembershipId,
     destinyVersion,
-    payload: {},
-    createdBy: appId
+    payload: {
+      deleted: result.rowCount,
+    },
+    createdBy: appId,
   });
 
   return { status: 'Success' };

--- a/api/server.test.ts
+++ b/api/server.test.ts
@@ -181,9 +181,7 @@ describe('settings', () => {
       ],
     };
 
-    await postRequestAuthed('/profile')
-      .send(request)
-      .expect(200);
+    await postRequestAuthed('/profile').send(request).expect(200);
 
     // Read settings back
     const response = await getRequestAuthed(
@@ -620,7 +618,7 @@ describe('audit', () => {
     const auditResult = await getRequestAuthed('/audit').expect(200);
 
     const matchingEntry = auditResult.body.log.find(
-      (e) => e.createdBy === 'test-app'
+      (e) => e.type === 'loadout'
     );
     const expectedEntry = {
       createdAt: matchingEntry.createdAt,
@@ -657,9 +655,7 @@ async function importData() {
     (await promisify(readFile)('./dim-data.json')).toString()
   );
 
-  await postRequestAuthed('/import')
-    .send(file)
-    .expect(200);
+  await postRequestAuthed('/import').send(file).expect(200);
 
   return file;
 }

--- a/api/shapes/audit-log.ts
+++ b/api/shapes/audit-log.ts
@@ -72,5 +72,7 @@ export interface ItemAnnotationLogEntry {
 
 export interface CleanupItemAnnotationLogEntry {
   type: 'tag_cleanup';
-  payload: {};
+  payload: {
+    deleted: number;
+  };
 }


### PR DESCRIPTION
1. I had typoed the ORDER BY on the audit query and sorted by created_by instead of created_at, which isn't what I meant at all.
2. I'd like to record how many tags got deleted by tag_cleanup.