### PR TITLE
Add a new audit log for when an auth token is minted

### DIFF
--- a/api/shapes/audit-log.ts
+++ b/api/shapes/audit-log.ts
@@ -23,6 +23,7 @@ export type AuditLogEntry = {
   | DeleteLoadoutLogEntry
   | ItemAnnotationLogEntry
   | CleanupItemAnnotationLogEntry
+  | AuthLogEntry
 );
 
 export interface ImportAuditLogEntry {
@@ -74,5 +75,12 @@ export interface CleanupItemAnnotationLogEntry {
   type: 'tag_cleanup';
   payload: {
     deleted: number;
+  };
+}
+
+export interface AuthLogEntry {
+  type: 'auth';
+  payload: {
+    userAgent: string;
   };
 }


### PR DESCRIPTION
I had this on a branch - the idea was that having a log of when a token was generated, and for roughly which browser, would help debug issues with data getting "wiped out" or not syncing across devices. Not sure that's happening enough to really warrant it though.