### PR TITLE
Allow tagging items by hash

### DIFF
--- a/api/db/item-hash-tags-queries.test.ts
+++ b/api/db/item-hash-tags-queries.test.ts
@@ -1,0 +1,128 @@
+import { transaction, pool } from '.';
+import {
+  updateItemHashTag,
+  getItemHashTagsForProfile,
+  deleteAllItemHashTags,
+  deleteItemHashTag,
+} from './item-hash-tags-queries';
+
+const appId = 'settings-queries-test-app';
+const bungieMembershipId = 4321;
+
+beforeEach(() =>
+  transaction(async (client) => {
+    await deleteAllItemHashTags(client, bungieMembershipId);
+  })
+);
+
+afterAll(() => pool.end());
+
+it('can insert item hash tags where none exist before', async () => {
+  await transaction(async (client) => {
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: 'favorite',
+      notes: 'the best',
+    });
+
+    const annotations = await getItemHashTagsForProfile(
+      client,
+      bungieMembershipId
+    );
+    expect(annotations[0]).toEqual({
+      hash: 123456,
+      tag: 'favorite',
+      notes: 'the best',
+    });
+  });
+});
+
+it('can update item hash tags where none exist before', async () => {
+  await transaction(async (client) => {
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: 'favorite',
+      notes: 'the best',
+    });
+
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: 'junk',
+      notes: 'the worst',
+    });
+
+    const annotations = await getItemHashTagsForProfile(
+      client,
+      bungieMembershipId
+    );
+    expect(annotations[0]).toEqual({
+      hash: 123456,
+      tag: 'junk',
+      notes: 'the worst',
+    });
+  });
+});
+
+it('can update item hash tags clearing value', async () => {
+  await transaction(async (client) => {
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: 'favorite',
+      notes: 'the best',
+    });
+
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: null,
+    });
+
+    const annotations = await getItemHashTagsForProfile(
+      client,
+      bungieMembershipId
+    );
+    expect(annotations[0]).toEqual({
+      hash: 123456,
+      notes: 'the best',
+    });
+  });
+});
+
+it('can delete item hash tags', async () => {
+  await transaction(async (client) => {
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: 'favorite',
+      notes: 'the best',
+    });
+
+    await deleteItemHashTag(client, bungieMembershipId, 123456);
+
+    const annotations = await getItemHashTagsForProfile(
+      client,
+      bungieMembershipId
+    );
+    expect(annotations).toEqual([]);
+  });
+});
+
+it('can delete item hash tags by setting both values to null/empty', async () => {
+  await transaction(async (client) => {
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: 'favorite',
+      notes: 'the best',
+    });
+
+    await updateItemHashTag(client, appId, bungieMembershipId, {
+      hash: 123456,
+      tag: null,
+      notes: '',
+    });
+
+    const annotations = await getItemHashTagsForProfile(
+      client,
+      bungieMembershipId
+    );
+    expect(annotations).toEqual([]);
+  });
+});

--- a/api/db/item-hash-tags-queries.ts
+++ b/api/db/item-hash-tags-queries.ts
@@ -1,0 +1,110 @@
+import { ClientBase, QueryResult } from 'pg';
+import { ItemHashTag } from '../shapes/item-annotations';
+import { metrics } from '../metrics';
+
+/**
+ * Get all of the hash tags for a particular platform_membership_id and destiny_version.
+ */
+export async function getItemHashTagsForProfile(
+  client: ClientBase,
+  bungieMembershipId: number
+): Promise<ItemHashTag[]> {
+  const results = await client.query({
+    name: 'get_item_hash_tags',
+    text:
+      'SELECT item_hash, tag, notes FROM item_hash_tags WHERE membership_id = $1',
+    values: [bungieMembershipId],
+  });
+  return results.rows.map(convertItemHashTag);
+}
+
+function convertItemHashTag(row: any): ItemHashTag {
+  const result: ItemHashTag = {
+    hash: row.item_hash,
+  };
+  if (row.tag) {
+    result.tag = row.tag;
+  }
+  if (row.notes) {
+    result.notes = row.notes;
+  }
+  return result;
+}
+
+/**
+ * Insert or update (upsert) a single item annotation. Loadouts are totally replaced when updated.
+ */
+export async function updateItemHashTag(
+  client: ClientBase,
+  appId: string,
+  bungieMembershipId: number,
+  itemHashTag: ItemHashTag
+): Promise<QueryResult<any>> {
+  const tagValue = clearValue(itemHashTag.tag);
+  const notesValue = clearValue(itemHashTag.notes);
+
+  if (tagValue === 'clear' && notesValue === 'clear') {
+    return deleteItemHashTag(client, bungieMembershipId, itemHashTag.hash);
+  }
+
+  const response = await client.query({
+    name: 'upsert_hash_tag',
+    text: `insert INTO item_hash_tags (membership_id, item_hash, tag, notes, created_by, last_updated_by)
+values ($1, $2, (CASE WHEN $3 = 'clear'::item_tag THEN NULL ELSE $3 END)::item_tag, (CASE WHEN $4 = 'clear' THEN NULL ELSE $4 END), $5, $5)
+on conflict (membership_id, item_hash)
+do update set (tag, notes, last_updated_at, last_updated_by) = ((CASE WHEN $3 = 'clear' THEN NULL WHEN $3 IS NULL THEN item_hash_tags.tag ELSE $3 END), (CASE WHEN $4 = 'clear' THEN NULL WHEN $4 IS NULL THEN item_hash_tags.notes ELSE $4 END), current_timestamp, $5)`,
+    values: [bungieMembershipId, itemHashTag.hash, tagValue, notesValue, appId],
+  });
+
+  if (response.rowCount < 1) {
+    // This should never happen!
+    metrics.increment('db.itemHashTags.noRowUpdated.count', 1);
+    throw new Error('No row was updated');
+  }
+
+  return response;
+}
+
+/**
+ * If the value is explicitly set to null or empty string, we return "clear" which will remove the value from the database.
+ * If it's undefined we return null, which will preserve the existing value.
+ * If it's set, we'll return the input which will update the existing value.
+ */
+function clearValue(val: string | null | undefined) {
+  if (val === null || (val !== undefined && val.length === 0)) {
+    return 'clear';
+  } else if (!val) {
+    return null;
+  } else {
+    return val;
+  }
+}
+
+/**
+ * Delete an item hash tags.
+ */
+export async function deleteItemHashTag(
+  client: ClientBase,
+  bungieMembershipId: number,
+  itemHash: number
+): Promise<QueryResult<any>> {
+  return client.query({
+    name: 'delete_item_hash_tag',
+    text: `delete from item_hash_tags where membership_id = $1 and item_hash = $2`,
+    values: [bungieMembershipId, itemHash],
+  });
+}
+
+/**
+ * Delete all item hash tags for a user.
+ */
+export async function deleteAllItemHashTags(
+  client: ClientBase,
+  bungieMembershipId: number
+): Promise<QueryResult<any>> {
+  return client.query({
+    name: 'delete_all_item_hash_tags',
+    text: `delete from item_hash_tags where membership_id = $1`,
+    values: [bungieMembershipId],
+  });
+}

--- a/api/migrations/20200707023029-hash-tags.js
+++ b/api/migrations/20200707023029-hash-tags.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+// I'll probably regret this name, but it's basically item_annotations keyed by item hash instead of instance ID. For shaders.
+// Hash-based tags D2-only and aren't specific to one profile - if you like a shader, you like it everywhere.
+exports.up = function (db, callback) {
+  db.runSql(
+    `
+    CREATE TABLE item_hash_tags (
+      membership_id int NOT NULL,
+      item_hash int NOT NULL,
+      tag item_tag,
+      notes text,
+      created_at timestamp NOT NULL default current_timestamp,
+      created_by text NOT NULL,
+      last_updated_at timestamp NOT NULL default current_timestamp,
+      last_updated_by text NOT NULL,
+      /* tags are unique by membership ID and item hash - effectively they're scoped by user */
+      PRIMARY KEY(membership_id, item_hash)
+    );
+
+    CREATE INDEX item_hash_tags_by_membership ON item_annotations (membership_id);
+    `,
+    callback
+  );
+};
+
+exports.down = function (db, callback) {
+  db.dropTable('hash_tags', callback);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/routes/delete-all-data.ts
+++ b/api/routes/delete-all-data.ts
@@ -7,6 +7,7 @@ import { ClientBase } from 'pg';
 import { recordAuditLog } from '../db/audit-log-queries';
 import { DeleteAllResponse } from '../shapes/delete-all';
 import { deleteAllTrackedTriumphs } from '../db/triumphs-queries';
+import { deleteAllItemHashTags } from '../db/item-hash-tags-queries';
 
 /**
  * Delete My Data - this allows a user to wipe all their data from DIM storage.
@@ -39,6 +40,8 @@ export async function deleteAllData(
     settings: (await deleteSettings(client, bungieMembershipId)).rowCount,
     loadouts: (await deleteAllLoadouts(client, bungieMembershipId)).rowCount,
     tags: (await deleteAllItemAnnotations(client, bungieMembershipId)).rowCount,
+    itemHashTags: (await deleteAllItemHashTags(client, bungieMembershipId))
+      .rowCount,
     triumphs: (await deleteAllTrackedTriumphs(client, bungieMembershipId))
       .rowCount,
   };

--- a/api/routes/export.ts
+++ b/api/routes/export.ts
@@ -5,6 +5,7 @@ import { getAllLoadoutsForUser } from '../db/loadouts-queries';
 import { getAllItemAnnotationsForUser } from '../db/item-annotations-queries';
 import { ExportResponse } from '../shapes/export';
 import { getAllTrackedTriumphsForUser } from '../db/triumphs-queries';
+import { getItemHashTagsForProfile } from '../db/item-hash-tags-queries';
 
 export const exportHandler = asyncHandler(async (req, res) => {
   const { bungieMembershipId } = req.user!;
@@ -13,6 +14,10 @@ export const exportHandler = asyncHandler(async (req, res) => {
     const settings = await getSettings(client, bungieMembershipId);
     const loadouts = await getAllLoadoutsForUser(client, bungieMembershipId);
     const itemAnnotations = await getAllItemAnnotationsForUser(
+      client,
+      bungieMembershipId
+    );
+    const itemHashTags = await getItemHashTagsForProfile(
       client,
       bungieMembershipId
     );
@@ -25,6 +30,7 @@ export const exportHandler = asyncHandler(async (req, res) => {
       settings,
       loadouts,
       tags: itemAnnotations,
+      itemHashTags,
       triumphs,
     };
 

--- a/api/routes/import.ts
+++ b/api/routes/import.ts
@@ -107,19 +107,6 @@ export const importHandler = asyncHandler(async (req, res) => {
       }
     }
 
-    for (const triumphData of triumphs) {
-      for (const triumph of triumphData.triumphs) {
-        trackTriumph(
-          client,
-          appId,
-          bungieMembershipId,
-          triumphData.platformMembershipId,
-          triumph
-        );
-        numTriumphs++;
-      }
-    }
-
     await recordAuditLog(client, bungieMembershipId, {
       type: 'import',
       payload: {

--- a/api/routes/import.ts
+++ b/api/routes/import.ts
@@ -14,6 +14,7 @@ import { badRequest } from '../utils';
 import _ from 'lodash';
 import { ImportResponse } from '../shapes/import';
 import { trackTriumph } from '../db/triumphs-queries';
+import { updateItemHashTag } from '../db/item-hash-tags-queries';
 
 export interface DimData {
   // The last selected platform membership ID
@@ -41,6 +42,7 @@ export const importHandler = asyncHandler(async (req, res) => {
   const loadouts = extractLoadouts(importData);
   const itemAnnotations = extractItemAnnotations(importData);
   const triumphs = extractTriumphs(importData);
+  const itemHashTags = importData.itemHashTags || [];
 
   if (
     _.isEmpty(settings) &&
@@ -88,6 +90,23 @@ export const importHandler = asyncHandler(async (req, res) => {
       );
     }
 
+    for (const tag of itemHashTags) {
+      await updateItemHashTag(client, appId, bungieMembershipId, tag);
+    }
+
+    for (const triumphData of triumphs) {
+      for (const triumph of triumphData.triumphs) {
+        trackTriumph(
+          client,
+          appId,
+          bungieMembershipId,
+          triumphData.platformMembershipId,
+          triumph
+        );
+        numTriumphs++;
+      }
+    }
+
     for (const triumphData of triumphs) {
       for (const triumph of triumphData.triumphs) {
         trackTriumph(
@@ -107,6 +126,7 @@ export const importHandler = asyncHandler(async (req, res) => {
         loadouts: loadouts.length,
         tags: itemAnnotations.length,
         triumphs: numTriumphs,
+        itemHashTags: itemHashTags.length,
       },
       createdBy: appId,
     });
@@ -116,6 +136,7 @@ export const importHandler = asyncHandler(async (req, res) => {
     loadouts: loadouts.length,
     tags: itemAnnotations.length,
     triumphs: numTriumphs,
+    itemHashTags: itemHashTags.length,
   };
 
   // default 200 OK

--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -8,6 +8,7 @@ import { ProfileResponse } from '../shapes/profile';
 import { DestinyVersion } from '../shapes/general';
 import { defaultSettings } from '../shapes/settings';
 import { getTrackedTriumphsForProfile } from '../db/triumphs-queries';
+import { getItemHashTagsForProfile } from '../db/item-hash-tags-queries';
 
 export const profileHandler = asyncHandler(async (req, res) => {
   const { bungieMembershipId } = req.user!;
@@ -60,6 +61,13 @@ export const profileHandler = asyncHandler(async (req, res) => {
         bungieMembershipId,
         platformMembershipId,
         destinyVersion
+      );
+    }
+
+    if (components.includes('hashtags')) {
+      response.itemHashTags = await getItemHashTagsForProfile(
+        client,
+        bungieMembershipId
       );
     }
 

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -4,6 +4,7 @@ import {
   ProfileUpdateRequest,
   ProfileUpdateResult,
   TrackTriumphUpdate,
+  ItemHashTagUpdate,
 } from '../shapes/profile';
 import { badRequest } from '../utils';
 import { ClientBase } from 'pg';
@@ -26,6 +27,7 @@ import {
   trackTriumph as trackTriumphInDb,
   unTrackTriumph,
 } from '../db/triumphs-queries';
+import { updateItemHashTag as updateItemHashTagInDb } from '../db/item-hash-tags-queries';
 
 /**
  * Update profile information. This accepts a list of update operations and
@@ -98,6 +100,15 @@ export const updateHandler = asyncHandler(async (req, res) => {
             bungieMembershipId,
             platformMembershipId,
             destinyVersion,
+            update.payload
+          );
+          break;
+
+        case 'item_hash_tag':
+          result = await updateItemHashTag(
+            client,
+            appId,
+            bungieMembershipId,
             update.payload
           );
           break;
@@ -374,6 +385,23 @@ async function trackTriumph(
     type: 'track_triumph',
     platformMembershipId,
     destinyVersion: 2,
+    payload,
+    createdBy: appId,
+  });
+
+  return { status: 'Success' };
+}
+
+async function updateItemHashTag(
+  client: ClientBase,
+  appId: string,
+  bungieMembershipId: number,
+  payload: ItemHashTagUpdate['payload']
+): Promise<ProfileUpdateResult> {
+  await updateItemHashTagInDb(client, appId, bungieMembershipId, payload);
+
+  await recordAuditLog(client, bungieMembershipId, {
+    type: 'item_hash_tag',
     payload,
     createdBy: appId,
   });

--- a/api/server.test.ts
+++ b/api/server.test.ts
@@ -146,6 +146,7 @@ describe('profile', () => {
       loadouts: 12,
       tags: 51,
       triumphs: 0,
+      itemHashTags: 0,
     });
 
     // Now re-export and make sure it's all gone
@@ -578,6 +579,184 @@ describe('tags', () => {
         {
           action: 'tag_cleanup',
           payload: ['1234567', '7654321'],
+        },
+      ],
+    };
+
+    const updateResult2 = await postRequestAuthed('/profile')
+      .send(request2)
+      .expect(200);
+
+    expect(updateResult2.body.results[0].status).toBe('Success');
+
+    // Read tags back
+    const response = await getRequestAuthed(
+      `/profile?components=tags&platformMembershipId=${platformMembershipId}`
+    ).expect(200);
+
+    const profileResponse = response.body as ProfileResponse;
+
+    expect(profileResponse.tags?.length).toBe(0);
+  });
+});
+
+describe('item hash tags', () => {
+  beforeEach(() => postRequestAuthed('/delete_all_data').expect(200));
+
+  it('can add an item hash tag', async () => {
+    const request: ProfileUpdateRequest = {
+      updates: [
+        {
+          action: 'item_hash_tag',
+          payload: {
+            hash: 1234,
+            tag: 'favorite',
+          },
+        },
+      ],
+    };
+
+    const updateResult = await postRequestAuthed('/profile')
+      .send(request)
+      .expect(200);
+
+    expect(updateResult.body.results[0].status).toBe('Success');
+
+    // Read tags back
+    const response = await getRequestAuthed(
+      `/profile?components=hashtags&platformMembershipId=${platformMembershipId}`
+    ).expect(200);
+
+    const profileResponse = response.body as ProfileResponse;
+
+    expect(profileResponse.itemHashTags?.length).toBe(1);
+    const resultTag = profileResponse.itemHashTags![0];
+    expect(resultTag).toEqual({
+      hash: 1234,
+      tag: 'favorite',
+    });
+  });
+
+  it('can update an item hash tag', async () => {
+    const request: ProfileUpdateRequest = {
+      updates: [
+        {
+          action: 'item_hash_tag',
+          payload: {
+            hash: 1234,
+            tag: 'favorite',
+          },
+        },
+      ],
+    };
+
+    const updateResult = await postRequestAuthed('/profile')
+      .send(request)
+      .expect(200);
+
+    expect(updateResult.body.results[0].status).toBe('Success');
+
+    // Change tag and notes
+    const request2: ProfileUpdateRequest = {
+      updates: [
+        {
+          action: 'item_hash_tag',
+          payload: {
+            hash: 1234,
+            tag: 'junk',
+            notes: 'super junky',
+          },
+        },
+      ],
+    };
+
+    const updateResult2 = await postRequestAuthed('/profile')
+      .send(request2)
+      .expect(200);
+
+    expect(updateResult2.body.results[0].status).toBe('Success');
+
+    // Read tags back
+    const response = await getRequestAuthed(
+      `/profile?components=hashtags&platformMembershipId=${platformMembershipId}`
+    ).expect(200);
+
+    const profileResponse = response.body as ProfileResponse;
+
+    expect(profileResponse.itemHashTags?.length).toBe(1);
+    const resultTag = profileResponse.itemHashTags![0];
+    expect(resultTag).toEqual({
+      hash: 1234,
+      tag: 'junk',
+      notes: 'super junky',
+    });
+
+    // Delete tag
+    const request3: ProfileUpdateRequest = {
+      updates: [
+        {
+          action: 'item_hash_tag',
+          payload: {
+            hash: 1234,
+            tag: null,
+          },
+        },
+      ],
+    };
+
+    const updateResult3 = await postRequestAuthed('/profile')
+      .send(request3)
+      .expect(200);
+
+    expect(updateResult3.body.results[0].status).toBe('Success');
+
+    // Read tags back after deleting the tag
+    const response2 = await getRequestAuthed(
+      `/profile?components=hashtags&platformMembershipId=${platformMembershipId}`
+    ).expect(200);
+
+    const profileResponse2 = response2.body as ProfileResponse;
+
+    expect(profileResponse2.itemHashTags?.length).toBe(1);
+    const resultTag2 = profileResponse2.itemHashTags![0];
+    expect(resultTag2).toEqual({
+      hash: 1234,
+      notes: 'super junky',
+    });
+  });
+
+  it('can delete an item hash tag', async () => {
+    const request: ProfileUpdateRequest = {
+      updates: [
+        {
+          action: 'item_hash_tag',
+          payload: {
+            hash: 1234,
+            tag: 'favorite',
+            notes: 'the best',
+          },
+        },
+      ],
+    };
+
+    const updateResult = await postRequestAuthed('/profile')
+      .send(request)
+      .expect(200);
+
+    expect(updateResult.body.results[0].status).toBe('Success');
+
+    // delete tag and notes
+    const request2: ProfileUpdateRequest = {
+      platformMembershipId,
+      destinyVersion: 2,
+      updates: [
+        {
+          action: 'item_hash_tag',
+          payload: {
+            hash: 1234,
+            tag: null,
+            notes: '',
+          },
         },
       ],
     };

--- a/api/shapes/audit-log.ts
+++ b/api/shapes/audit-log.ts
@@ -1,5 +1,5 @@
 import { Settings } from './settings';
-import { ItemAnnotation } from './item-annotations';
+import { ItemAnnotation, ItemHashTag } from './item-annotations';
 import { DestinyVersion } from './general';
 import { DeleteAllResponse } from './delete-all';
 import { TrackTriumphUpdate } from './profile';
@@ -24,6 +24,7 @@ export type AuditLogEntry = {
   | LoadoutLogEntry
   | DeleteLoadoutLogEntry
   | ItemAnnotationLogEntry
+  | ItemHashTagLogEntry
   | CleanupItemAnnotationLogEntry
   | TrackTriumphLogEntry
   | AuthLogEntry
@@ -36,6 +37,7 @@ export interface ImportAuditLogEntry {
     loadouts: number;
     tags: number;
     triumphs: number;
+    itemHashTags: number;
   };
 }
 
@@ -69,6 +71,11 @@ export interface DeleteLoadoutLogEntry {
 export interface ItemAnnotationLogEntry {
   type: 'tag';
   payload: ItemAnnotation;
+}
+
+export interface ItemHashTagLogEntry {
+  type: 'item_hash_tag';
+  payload: ItemHashTag;
 }
 
 export interface CleanupItemAnnotationLogEntry {

--- a/api/shapes/delete-all.ts
+++ b/api/shapes/delete-all.ts
@@ -3,6 +3,7 @@ export interface DeleteAllResponse {
     settings: number;
     loadouts: number;
     tags: number;
+    itemHashTags: number;
     triumphs: number;
   };
 }

--- a/api/shapes/export.ts
+++ b/api/shapes/export.ts
@@ -1,5 +1,5 @@
 import { Settings } from './settings';
-import { ItemAnnotation } from './item-annotations';
+import { ItemAnnotation, ItemHashTag } from './item-annotations';
 import { DestinyVersion } from './general';
 import { Loadout } from './loadouts';
 
@@ -15,6 +15,7 @@ export interface ExportResponse {
     destinyVersion: DestinyVersion;
     annotation: ItemAnnotation;
   }[];
+  itemHashTags: ItemHashTag[];
   triumphs: {
     platformMembershipId: string;
     triumphs: number[];

--- a/api/shapes/import.ts
+++ b/api/shapes/import.ts
@@ -1,5 +1,6 @@
 export interface ImportResponse {
   loadouts: number;
   tags: number;
+  itemHashTags: number;
   triumphs: number;
 }

--- a/api/shapes/item-annotations.ts
+++ b/api/shapes/item-annotations.ts
@@ -9,3 +9,13 @@ export interface ItemAnnotation {
   /** Optional text notes on the item. */
   notes?: string | null;
 }
+
+/** Any extra info added by the user to item hashes (shaders, basically) */
+export interface ItemHashTag {
+  /** The inventory item hash for an item */
+  hash: number;
+  /** Optional tag for the item. */
+  tag?: TagValue | null;
+  /** Optional text notes on the item. */
+  notes?: string | null;
+}

--- a/api/shapes/profile.ts
+++ b/api/shapes/profile.ts
@@ -1,12 +1,14 @@
 import { Settings } from './settings';
 import { Loadout } from './loadouts';
-import { ItemAnnotation } from './item-annotations';
+import { ItemAnnotation, ItemHashTag } from './item-annotations';
 import { DestinyVersion } from './general';
 
 export interface ProfileResponse {
   settings?: Settings;
   loadouts?: Loadout[];
   tags?: ItemAnnotation[];
+  /** Tags for shaders and other uninstanced items */
+  itemHashTags?: ItemHashTag[];
   /** Hashes of tracked triumphs */
   triumphs?: number[];
 }
@@ -26,6 +28,7 @@ export interface ProfileUpdateResponse {
 
 export type ProfileUpdate =
   | TagUpdate
+  | ItemHashTagUpdate
   | TagCleanupUpdate
   | SettingUpdate
   | LoadoutUpdate
@@ -35,6 +38,11 @@ export type ProfileUpdate =
 export interface TagUpdate {
   action: 'tag';
   payload: ItemAnnotation;
+}
+
+export interface ItemHashTagUpdate {
+  action: 'item_hash_tag';
+  payload: ItemHashTag;
 }
 
 export interface TagCleanupUpdate {


### PR DESCRIPTION
I took one pass at this where I stored by-hash tags in the same table as regular tags, but ended up backing up and doing it over as a separate table. I think this ends up cleaner, and it lets API consumers choose whether or not to use this data. It also lets me make by-hash tags D2-only and not tied to profile.

The main deal for this is to allow tagging shaders.