### PR TITLE
Trim audit log on updates to 500 entries

### DIFF
--- a/api/db/audit-log-queries.ts
+++ b/api/db/audit-log-queries.ts
@@ -53,3 +53,20 @@ values ($1, $2, $3, $4, $5, $6)`,
 
   return response;
 }
+
+/**
+ * Trim old entries from the audit log, keeping only the numToKeep latest records.
+ */
+export async function trimAuditLog(
+  client: ClientBase,
+  bungieMembershipId: number,
+  numToKeep: number
+): Promise<QueryResult<any>> {
+  const response = await client.query({
+    name: 'trim_audit_log',
+    text: `DELETE FROM audit_log WHERE ctid IN (SELECT ctid FROM audit_log WHERE membership_id = $1 ORDER BY created_at DESC, id DESC OFFSET $2)`,
+    values: [bungieMembershipId, numToKeep],
+  });
+
+  return response;
+}

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -24,7 +24,7 @@ import {
 } from '../db/item-annotations-queries';
 import { ItemAnnotation } from '../shapes/item-annotations';
 import { metrics } from '../metrics';
-import { recordAuditLog } from '../db/audit-log-queries';
+import { recordAuditLog, trimAuditLog } from '../db/audit-log-queries';
 import {
   trackTriumph as trackTriumphInDb,
   unTrackTriumph,
@@ -155,6 +155,8 @@ export const updateHandler = asyncHandler(async (req, res) => {
       }
       results.push(result);
     }
+
+    await trimAuditLog(client, bungieMembershipId, 500);
   });
 
   res.send({


### PR DESCRIPTION
We're starting to use a significant amount of DB space on audit log (>5GB) so I'd like to clean up the log to the last 500 entries on every update.