### PR TITLE
Add loadout optimizer parameters to loadouts

### DIFF
--- a/api/shapes/loadouts.ts
+++ b/api/shapes/loadouts.ts
@@ -25,4 +25,43 @@ export interface Loadout {
   // Lists of equipped and unequipped items in the loadout
   equipped: LoadoutItem[];
   unequipped: LoadoutItem[];
+  /** Information about the desired properties of this loadout - used to drive the Loadout Optimizer or apply Mod Loadouts */
+  parameters?: LoadoutParameters;
+}
+
+/**
+ * Parameters that explain how this loadout was chosen (in Loadout Optimizer) and at the
+ * same time, how this loadout should be configured when equipped. This can be used to
+ * re-load a loadout into Loadout Optimizer with its settings intact, or to equip the right
+ * mods when applying a loadout if AWA is ever released.
+ */
+export interface LoadoutParameters {
+  /**
+   * The stats the user cared about for this loadout, in the order they cared about them and
+   * with optional range by tier. If a stat is "ignored" it should just be missing from this
+   * list.
+   */
+  statConstraints?: StatConstraint[];
+  /**
+   * The mods that will be used with this loadout. Each entry is an inventory item hash representing
+   * the mod item. Hashes may appear multiple times. These are not associated with any specific
+   * item in the loadout - when applying the loadout we should automatically determine the minimum
+   * of changes required to match the desired mods.
+   */
+  mods?: number[];
+  /**
+   * A search filter applied while editing the loadout in Loadout Optimizer, which constrains the
+   * items that can be in the loadout.
+   */
+  query?: string[];
+}
+
+/** A constraint on the values an armor stat can take */
+export interface StatConstraint {
+  /** The stat definition hash of the stat */
+  statHash?: number;
+  /** The minimum tier value for the stat. 0 if unset. */
+  minTier?: number;
+  /** The maximum tier value for the stat. 10 if unset. */
+  maxTier?: number;
 }

--- a/api/shapes/loadouts.ts
+++ b/api/shapes/loadouts.ts
@@ -54,6 +54,12 @@ export interface LoadoutParameters {
    * items that can be in the loadout.
    */
   query?: string[];
+
+  /**
+   * When generating the loadout, did we assume all items were at their masterworked stats, or did
+   * we use their current stats?
+   */
+  assumeMasterworked?: boolean;
 }
 
 /** A constraint on the values an armor stat can take */

--- a/dim-api-types/package.json
+++ b/dim-api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@destinyitemmanager/dim-api-types",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "TypeScript types for the DIM API",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
This proposes an extension to the storage model for Loadouts. I'm thinking of two use cases:

1. Use loadout optimizer to create a loadout, and when it's saved, save the parameters you used to find that loadout with the loadout itself. Then you can open that loadout, click "Edit in Loadout Optimizer" and it will open up LO with all the settings configured correctly, and you can update the loadout right there and re-save it. This should make the workflow of "I got some new drops, can I make my loadout better with them" easy.
  a. There's also a side benefit which is we can show the parameters in an expanded loadout menu / loadout management page and on the loadout drawer to remind people what mods and stat priorities they chose.
2. If we get AWA (advanced write actions), then when you apply a loadout we could automatically equip the correct mods.

There are some interesting notes here:

1. I'm hoping we can get away with a flat list of mods, without associating them with buckets. My thought is that we should be automatically assigning mods to items based on what will fit, and when you apply the loadout, we should just do whatever the cheapest set of options to get the right things slotted is. This would actually imply that we stop storing mods per bucket in LO as well.
2. A bunch of settings like assume masterwork, minimum stat total, etc are not part of this. I'm not sure if they should be. On one hand, they don't seem that loadout specific. However, not saving them with the loadout may prevent the same loadout from being found on round-tripping it.
3. The StatConstraints and stat order are combined in a kind of awkward way - not sure if there's something better.
4. Locking/excluding individual items is not included. Should it be?
5. Locking/excluding element is not included. Should it be? I tend to think people should lock mods and we should remove the ability to lock element in order to push people towards locking mods.
6. We can encode these parameters into a URL and allow people to share links to "mod loadouts" that automatically open in LO. Wouldn't that be cool?