### PR TITLE
Deprecated a no longer used upgrade tier option.

### DIFF
--- a/api/shapes/settings.ts
+++ b/api/shapes/settings.ts
@@ -38,6 +38,10 @@ export enum UpgradeSpendTier {
   AscendantShardsNotExotic,
   AscendantShards,
   AscendantShardsNotMasterworked,
+  /**
+   * @deprecated
+   * No longer needed with the lock energy toggle, treat this as if it was the Nothing option.
+   */
   AscendantShardsLockEnergyType,
 }
 


### PR DESCRIPTION
I can either do this, delete the option in the api and have a special handler method for it, or delete the option in the api and write a sql script to update things. Would prefer the later but can do whichever.