### PR TITLE
Deprecate settings, consolidate loadout parameters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "prettier/@typescript-eslint"
+    "prettier"
   ],
   "globals": {},
   "parserOptions": {

--- a/api/db/settings-queries.test.ts
+++ b/api/db/settings-queries.test.ts
@@ -9,7 +9,7 @@ afterAll(() => pool.end());
 it('can insert settings where none exist before', async () => {
   await transaction(async (client) => {
     await setSetting(client, appId, bungieMembershipId, {
-      showNewItems: true
+      showNewItems: true,
     });
 
     const settings = await getSettings(client, bungieMembershipId);
@@ -20,17 +20,35 @@ it('can insert settings where none exist before', async () => {
 it('can update settings', async () => {
   await transaction(async (client) => {
     await setSetting(client, appId, bungieMembershipId, {
-      showNewItems: true
+      showNewItems: true,
     });
 
     const settings = await getSettings(client, bungieMembershipId);
     expect(settings.showNewItems).toBe(true);
 
     await setSetting(client, appId, bungieMembershipId, {
-      showNewItems: false
+      showNewItems: false,
     });
 
     const settings2 = await getSettings(client, bungieMembershipId);
     expect(settings2.showNewItems).toBe(false);
+  });
+});
+
+it('can partially update settings', async () => {
+  await transaction(async (client) => {
+    await setSetting(client, appId, bungieMembershipId, {
+      showNewItems: true,
+    });
+
+    const settings = await getSettings(client, bungieMembershipId);
+    expect(settings.showNewItems).toBe(true);
+
+    await setSetting(client, appId, bungieMembershipId, {
+      singleCharacter: true,
+    });
+
+    const settings2 = await getSettings(client, bungieMembershipId);
+    expect(settings2.showNewItems).toBe(true);
   });
 });

--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -34,9 +34,10 @@ export const profileHandler = asyncHandler(async (req, res) => {
 
     if (components.includes('settings')) {
       const start = new Date();
+      const storedSettings = await getSettings(client, bungieMembershipId);
       response.settings = {
         ...defaultSettings,
-        ...(await getSettings(client, bungieMembershipId)),
+        ...storedSettings,
       };
       metrics.timing('profile.settings', start);
     }

--- a/api/shapes/loadouts.ts
+++ b/api/shapes/loadouts.ts
@@ -29,11 +29,30 @@ export interface Loadout {
   parameters?: LoadoutParameters;
 }
 
+/** The level of upgrades the user is willing to perform in order to fit mods into their loadout or hit stats. */
+export enum UpgradeSpendTier {
+  Nothing,
+  LegendaryShards,
+  EnhancementPrisms,
+  AscendantShardsNotExotic,
+  AscendantShards,
+  AscendantShardsNotMasterworked,
+  /**
+   * @deprecated
+   * No longer needed with the lock energy toggle, treat this as if it was the Nothing option.
+   */
+  AscendantShardsLockEnergyType,
+}
+
 /**
- * Parameters that explain how this loadout was chosen (in Loadout Optimizer) and at the
- * same time, how this loadout should be configured when equipped. This can be used to
- * re-load a loadout into Loadout Optimizer with its settings intact, or to equip the right
- * mods when applying a loadout if AWA is ever released.
+ * Parameters that explain how this loadout was chosen (in Loadout Optimizer)
+ * and at the same time, how this loadout should be configured when equipped.
+ * This can be used to re-load a loadout into Loadout Optimizer with its
+ * settings intact, or to equip the right mods when applying a loadout if AWA is
+ * ever released.
+ *
+ * All properties are optional, but most have defaults specified in
+ * defaultLoadoutParameters that should be used if they are undefined.
  */
 export interface LoadoutParameters {
   /**
@@ -42,25 +61,64 @@ export interface LoadoutParameters {
    * list.
    */
   statConstraints?: StatConstraint[];
+
   /**
-   * The mods that will be used with this loadout. Each entry is an inventory item hash representing
-   * the mod item. Hashes may appear multiple times. These are not associated with any specific
-   * item in the loadout - when applying the loadout we should automatically determine the minimum
-   * of changes required to match the desired mods.
+   * The mods that will be used with this loadout. Each entry is an inventory
+   * item hash representing the mod item. Hashes may appear multiple times.
+   * These are not associated with any specific item in the loadout - when
+   * applying the loadout we should automatically determine the minimum of
+   * changes required to match the desired mods.
    */
   mods?: number[];
   /**
-   * A search filter applied while editing the loadout in Loadout Optimizer, which constrains the
-   * items that can be in the loadout.
+   * A search filter applied while editing the loadout in Loadout Optimizer,
+   * which constrains the items that can be in the loadout.
    */
   query?: string;
 
   /**
-   * When generating the loadout, did we assume all items were at their masterworked stats, or did
-   * we use their current stats?
+   * When generating the loadout, did we assume all items were at their
+   * masterworked stats, or did we use their current stats?
+   *
+   * @deprecated use upgradeSpendTier
    */
   assumeMasterworked?: boolean;
+
+  /**
+   * What upgrades are the user willing to shell out for?
+   */
+  upgradeSpendTier?: UpgradeSpendTier;
+
+  /**
+   * The InventoryItemHash of the pinned exotic, if any was chosen.
+   */
+  exoticArmorHash?: number;
+
+  /**
+   * Don't change energy type of armor in order to fit mods.
+   */
+  lockItemEnergyType?: boolean;
 }
+
+/**
+ * All properties of LoadoutParameters are optional, in order to make them
+ * compact when shared. Before using LoadoutParameters, merge it with these
+ * defaults.
+ */
+export const defaultLoadoutParameters: LoadoutParameters = {
+  statConstraints: [
+    { statHash: 2996146975 }, //Mobility
+    { statHash: 392767087 }, //Resilience
+    { statHash: 1943323491 }, //Recovery
+    { statHash: 1735777505 }, //Discipline
+    { statHash: 144602215 }, //Intellect
+    { statHash: 4244567218 }, //Strength
+  ],
+  mods: [],
+  assumeMasterworked: false,
+  upgradeSpendTier: UpgradeSpendTier.Nothing,
+  lockItemEnergyType: false,
+};
 
 /** A constraint on the values an armor stat can take */
 export interface StatConstraint {

--- a/api/shapes/settings.ts
+++ b/api/shapes/settings.ts
@@ -1,5 +1,7 @@
 // Synced with the definitions in DIM/src/app/settings/reducer.ts
 
+import { LoadoutParameters, UpgradeSpendTier } from './loadouts';
+
 export type CharacterOrder =
   | 'mostRecent'
   | 'mostRecentReverse'
@@ -31,30 +33,25 @@ export enum DtrReviewPlatform {
   Pc = 3,
 }
 
-export enum UpgradeSpendTier {
-  Nothing,
-  LegendaryShards,
-  EnhancementPrisms,
-  AscendantShardsNotExotic,
-  AscendantShards,
-  AscendantShardsNotMasterworked,
-  /**
-   * @deprecated
-   * No longer needed with the lock energy toggle, treat this as if it was the Nothing option.
-   */
-  AscendantShardsLockEnergyType,
-}
-
 export interface Settings {
-  /** Show full details in item popup */
+  /**
+   * Show full details in item popup
+   * @deprecated
+   */
   readonly itemDetails: boolean;
   /** Show item quality percentages */
   readonly itemQuality: boolean;
   /** Show new items with an overlay */
   readonly showNewItems: boolean;
-  /** Show item reviews */
+  /**
+   * Show item reviews
+   * @deprecated
+   */
   readonly showReviews: boolean;
-  /** Can we post identifying information to DTR? */
+  /**
+   * Can we post identifying information to DTR?
+   * @deprecated
+   */
   readonly allowIdPostToDtr: boolean;
   /** Sort characters (mostRecent, mostRecentReverse, fixed) */
   readonly characterOrder: CharacterOrder;
@@ -62,6 +59,7 @@ export interface Settings {
    * Sort items in buckets (primaryStat, rarityThenPrimary, quality).
    * This used to let you set a preset but now it's always "custom"
    * unless loaded from an older settings.
+   * @deprecated
    */
   readonly itemSort: string;
   readonly itemSortOrderCustom: string[];
@@ -79,9 +77,15 @@ export interface Settings {
   readonly redactedRecordsRevealed: boolean;
   /** Whether to keep one slot per item type open */
   readonly farmingMakeRoomForItems: boolean;
-  /** Destiny 2 platform selection for ratings + reviews */
+  /**
+   * Destiny 2 platform selection for ratings + reviews
+   * @deprecated
+   */
   readonly reviewsPlatformSelectionV2: DtrReviewPlatform;
-  /** Destiny 2 play mode selection for ratings + reviews - see DestinyActivityModeType for values */
+  /**
+   * Destiny 2 play mode selection for ratings + reviews - see DestinyActivityModeType for values
+   * @deprecated
+   */
   readonly reviewsModeSelection: DtrD2ActivityModes;
 
   /** Hide completed Destiny 1 records */
@@ -93,13 +97,19 @@ export interface Settings {
   /** The last direction the infusion fuel finder was set to. */
   readonly infusionDirection: InfuseDirection;
 
-  /** Whether the item picker should equip or store. */
+  /**
+   * Whether the item picker should equip or store.
+   * @deprecated
+   */
   readonly itemPickerEquip: boolean;
 
   /** The user's preferred language. */
   readonly language: string;
 
-  /** Colorblind modes. */
+  /**
+   * Colorblind modes.
+   * @deprecated
+   */
   readonly colorA11y: string;
 
   /**
@@ -110,20 +120,46 @@ export interface Settings {
    */
   readonly wishListSource: string;
 
-  /** The initial stat order in the loadout opimizer. */
+  /**
+   * The last used settings for the Loadout Optimizer.
+   */
+  readonly loParameters: LoadoutParameters;
+
+  /**
+   * The initial stat order in the loadout optimizer.
+   * @deprecated use loParameters
+   */
   readonly loStatSortOrder: number[];
 
-  /** The initial status of assume masterwork in the loadout optimizer. */
+  /**
+   * The initial status of assume masterwork in the loadout optimizer.
+   * @deprecated use loParameters
+   */
   readonly loAssumeMasterwork: boolean;
 
-  /** The optimizers material spend tier, effects armors maximum energy when calcuating sets. */
+  /**
+   * The optimizers material spend tier, effects armors maximum energy when calcuating sets.
+   * @deprecated use loParameters
+   */
   readonly loUpgradeSpendTier: UpgradeSpendTier;
 
-  /** Thie minimum power for an armor set in the loadout optimizer. */
+  /**
+   * The minimum power for an armor set in the loadout optimizer.
+   * @deprecated
+   */
   readonly loMinPower: number;
 
-  /**The minimum stat total for a single armor piece in the loadout optimizer. */
+  /**
+   * The minimum stat total for a single armor piece in the loadout optimizer.
+   * @deprecated
+   */
   readonly loMinStatTotal: number;
+
+  /**
+   * Don't change energy type of armor in order to fit mods.
+   * @deprecated use loParameters
+   */
+  readonly loLockItemEnergyType: boolean;
 
   /** list of stat hashes of interest, keyed by class enum */
   readonly customTotalStatsByClass: {
@@ -136,12 +172,15 @@ export interface Settings {
   readonly organizerColumnsGhost: string[];
 
   /** Compare base stats or actual stats in Compare */
-  compareBaseStats: boolean;
+  readonly compareBaseStats: boolean;
   /** Item popup sidecar collapsed just shows icon and no character locations */
-  sidecarCollapsed: boolean;
+  readonly sidecarCollapsed: boolean;
 
   /** In "Single Character Mode" DIM pretends you only have one (active) character and all the other characters' items are in the vault. */
-  singleCharacter: boolean;
+  readonly singleCharacter: boolean;
+
+  /** Badge the app icon with the number of postmaster items on the current character */
+  readonly badgePostmaster: boolean;
 }
 
 export const defaultSettings: Settings = {
@@ -191,6 +230,7 @@ export const defaultSettings: Settings = {
   wishListSource:
     'https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/voltron.txt',
 
+  loParameters: {}, // Uses the defaults from defaultLoadoutParameters
   loStatSortOrder: [
     2996146975, //Mobility
     392767087, //Resilience
@@ -203,6 +243,7 @@ export const defaultSettings: Settings = {
   loUpgradeSpendTier: UpgradeSpendTier.Nothing,
   loMinPower: 750,
   loMinStatTotal: 55,
+  loLockItemEnergyType: false,
 
   customTotalStatsByClass: {},
   organizerColumnsWeapons: [
@@ -238,4 +279,5 @@ export const defaultSettings: Settings = {
   sidecarCollapsed: false,
 
   singleCharacter: false,
+  badgePostmaster: true,
 };

--- a/dim-api-types/package.json
+++ b/dim-api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@destinyitemmanager/dim-api-types",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "TypeScript types for the DIM API",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
A few changes here:

1. Deprecate old settings that aren't used anymore.
2. Deprecate all the loadout optimizer settings in favor of using a LoadoutParameters object, which is also what we'll be saving on loadouts to make them re-editable in LO. This change lets us keep those in sync.
3. Extend LoadoutParameters to cover all the new settings in LO.