### PR TITLE
Return loadout timestamps

### DIFF
--- a/api/db/loadouts-queries.ts
+++ b/api/db/loadouts-queries.ts
@@ -15,8 +15,7 @@ export async function getLoadoutsForProfile(
   try {
     const results = await client.query<Loadout>({
       name: 'get_loadouts_for_platform_membership_id',
-      text:
-        'SELECT id, name, class_type, emblem_hash, clear_space, items, parameters FROM loadouts WHERE membership_id = $1 and platform_membership_id = $2 and destiny_version = $3',
+      text: 'SELECT id, name, class_type, emblem_hash, clear_space, items, parameters, created_at, last_updated_at FROM loadouts WHERE membership_id = $1 and platform_membership_id = $2 and destiny_version = $3',
       values: [bungieMembershipId, platformMembershipId, destinyVersion],
     });
     return results.rows.map(convertLoadout);
@@ -41,8 +40,7 @@ export async function getAllLoadoutsForUser(
   try {
     const results = await client.query({
       name: 'get_all_loadouts_for_user',
-      text:
-        'SELECT membership_id, platform_membership_id, destiny_version, id, name, class_type, emblem_hash, clear_space, items, parameters FROM loadouts WHERE membership_id = $1',
+      text: 'SELECT membership_id, platform_membership_id, destiny_version, id, name, class_type, emblem_hash, clear_space, items, parameters, created_at, last_updated_at FROM loadouts WHERE membership_id = $1',
       values: [bungieMembershipId],
     });
     return results.rows.map((row) => {
@@ -66,6 +64,8 @@ function convertLoadout(row: any): Loadout {
     clearSpace: row.clear_space,
     equipped: row.items.equipped || [],
     unequipped: row.items.unequipped || [],
+    createdAt: row.created_at,
+    lastUpdatedAt: row.last_updated_at,
   };
   if (row.emblem_hash) {
     loadout.emblemHash = row.emblem_hash;

--- a/api/shapes/loadouts.ts
+++ b/api/shapes/loadouts.ts
@@ -27,6 +27,10 @@ export interface Loadout {
   unequipped: LoadoutItem[];
   /** Information about the desired properties of this loadout - used to drive the Loadout Optimizer or apply Mod Loadouts */
   parameters?: LoadoutParameters;
+  /** When was this Loadout initially created? Tracked automatically by the API - when saving a loadout this field is ignored. */
+  createdAt?: number;
+  /** When was this Loadout last changed? Tracked automatically by the API - when saving a loadout this field is ignored. */
+  lastUpdatedAt?: number;
 }
 
 /** The level of upgrades the user is willing to perform in order to fit mods into their loadout or hit stats. */


### PR DESCRIPTION
We've been tracking create time and update time for loadouts - I'd like to display/sort by those so let's start returning them.

One weird caveat here is that because these are auto-maintained database timestamps, if you import a backup, all your loadout timestamps will reset. That's unfortunate but maybe not enough for me to spend time doing something more complex.