### PR TITLE
Mods by bucket (for shaders)

### DIFF
--- a/api/shapes/loadouts.ts
+++ b/api/shapes/loadouts.ts
@@ -92,9 +92,21 @@ export interface LoadoutParameters {
    * item hash representing the mod item. Hashes may appear multiple times.
    * These are not associated with any specific item in the loadout - when
    * applying the loadout we should automatically determine the minimum of
-   * changes required to match the desired mods.
+   * changes required to match the desired mods, and apply these mods to the
+   * equipped items.
    */
   mods?: number[];
+
+  /**
+   * Mods that must be applied to a specific bucket hash. In general, prefer to
+   * use the flat mods list above, and rely on the loadout function to assign
+   * mods automatically. However there are some mods like shaders which can't
+   * be automatically assigned to the right piece. These only apply to the equipped
+   * item.
+   */
+  modsByBucket?: {
+    [bucketHash: number]: number[];
+  };
 
   /**
    * Whether to automatically add stat mods.


### PR DESCRIPTION
I'd like to add the ability to assign shaders and ornaments to loadouts. Ornaments are easy - they only go on items that they match, so they can be in the general mods list. But shaders are harder because we really need to know what piece they go on. I could use the new socketOverrides, but then the shader is tied to the exact instance of an item rather than the general slot - which may be fine for weapons but seems limiting for armor. I think the way to do that is to store mods by bucket on the mod parameters. That way when you share an armor loadout, it can include a "look" made up of shaders. So far I only really want to use this for shaders, but I'm leaving it a bit open ended.