### PR TITLE
Set limits on search query and loadout notes lengths

### DIFF
--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -401,10 +401,10 @@ async function recordSearch(
   // surgery to fix that, but we should probably just generally refuse to save
   // long queries.
   if (payload.query.length > 2048) {
-    metrics.increment('update.validation.platformMembershipIdMissing.count');
+    metrics.increment('update.validation.searchTooLong.count');
     return {
       status: 'InvalidArgument',
-      message: 'Tracked triumphs require platform membership ID to be set',
+      message: 'Search query must be under 2048 characters',
     };
   }
 
@@ -434,10 +434,10 @@ async function saveSearch(
   // surgery to fix that, but we should probably just generally refuse to save
   // long queries.
   if (payload.query.length > 2048) {
-    metrics.increment('update.validation.platformMembershipIdMissing.count');
+    metrics.increment('update.validation.searchTooLong.count');
     return {
       status: 'InvalidArgument',
-      message: 'Tracked triumphs require platform membership ID to be set',
+      message: 'Search query must be under 2048 characters',
     };
   }
 

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -208,6 +208,14 @@ async function updateLoadout(
     };
   }
 
+  if (loadout.notes && loadout.notes.length > 2048) {
+    metrics.increment('update.validation.loadoutNotesTooLong.count');
+    return {
+      status: 'InvalidArgument',
+      message: 'Loadout notes must be under 2048 characters',
+    };
+  }
+
   if (!loadout.id) {
     metrics.increment('update.loadoutIdMissing.count');
     return {
@@ -387,6 +395,19 @@ async function recordSearch(
   destinyVersion: DestinyVersion,
   payload: UsedSearchUpdate['payload']
 ): Promise<ProfileUpdateResult> {
+  // TODO: I did a silly thing and made the query part of the search table's
+  // primary key, instead of using a fixed-size hash of the query. This limits
+  // how big a query we can store (and bloats the index). I'll need to do some
+  // surgery to fix that, but we should probably just generally refuse to save
+  // long queries.
+  if (payload.query.length > 2048) {
+    metrics.increment('update.validation.platformMembershipIdMissing.count');
+    return {
+      status: 'InvalidArgument',
+      message: 'Tracked triumphs require platform membership ID to be set',
+    };
+  }
+
   const start = new Date();
   await updateUsedSearch(
     client,
@@ -407,6 +428,19 @@ async function saveSearch(
   destinyVersion: DestinyVersion,
   payload: SavedSearchUpdate['payload']
 ): Promise<ProfileUpdateResult> {
+  // TODO: I did a silly thing and made the query part of the search table's
+  // primary key, instead of using a fixed-size hash of the query. This limits
+  // how big a query we can store (and bloats the index). I'll need to do some
+  // surgery to fix that, but we should probably just generally refuse to save
+  // long queries.
+  if (payload.query.length > 2048) {
+    metrics.increment('update.validation.platformMembershipIdMissing.count');
+    return {
+      status: 'InvalidArgument',
+      message: 'Tracked triumphs require platform membership ID to be set',
+    };
+  }
+
   const start = new Date();
   await saveSearchInDb(
     client,


### PR DESCRIPTION
We can't accept search queries much longer than 2KB because of some bad data modeling decisions from me, and we never had a cap on loadout notes which seems bad. This caps both at 2KB.

See https://github.com/DestinyItemManager/DIM/pull/7714 for the UI side limit.