### PR TITLE
Preserve linebreaks in shared loadout notes

### DIFF
--- a/api/dim-gg/views/loadout.ejs
+++ b/api/dim-gg/views/loadout.ejs
@@ -31,7 +31,7 @@
     <div class="dim-page">
       <h1><%= loadout.name %></h1>
       <% if (loadout.notes) { %>
-      <p><%= loadout.notes %></p>
+      <p class="dim-notes"><%= loadout.notes %></p>
       <% } %>
       <p>
         These build settings contain:

--- a/dim-gg-static/loadout-share.css
+++ b/dim-gg-static/loadout-share.css
@@ -71,3 +71,7 @@ body {
   background-color: #e8a534 !important;
   color: black !important;
 }
+
+.dim-notes {
+  white-space: pre-line;
+}


### PR DESCRIPTION
Loadout in DIM:

![firefox_njGb0rgpMj](https://user-images.githubusercontent.com/226692/185443665-5799e5a8-fa9f-4847-841e-47969d5ed602.png)


Before:

![firefox_vMxN8wBq3M](https://user-images.githubusercontent.com/226692/185443676-c06f567f-2196-4927-9101-38b7dab08c39.png)

After:

![firefox_pFT5cKoTN5](https://user-images.githubusercontent.com/226692/185443684-6a90fc02-c43d-4dba-ad83-192f7b2ac1ea.png)