### PR TITLE
Add query hash for more efficient query uniqueness constraint

### DIFF
--- a/api/db/index.ts
+++ b/api/db/index.ts
@@ -4,7 +4,7 @@ import { metrics } from '../metrics';
 // pools will use environment variables
 // for connection information (from .env or a ConfigMap)
 export const pool = new Pool({
-  max: 2, // We get 25 connections per 1GB of RAM (we have 2GB), minus 3 connections for maintenance = 47. We run a variable number of DIM services.
+  max: 2, // We get 25 connections per 1GB of RAM (we have 4GB), minus 3 connections for maintenance = 97. We run a variable number of DIM services.
   ssl: process.env.PGSSL ? process.env.PGSSL === 'true' : { rejectUnauthorized: false },
   connectionTimeoutMillis: 500,
   // Statement query is at the Postgres side, times out any individual query

--- a/api/migrations/20221016230211-searches-hash.js
+++ b/api/migrations/20221016230211-searches-hash.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  db.runSql(
+    `ALTER TABLE searches ADD COLUMN qhash bytea GENERATED ALWAYS AS (decode(md5(query), 'hex')) STORED;`,
+    callback
+  );
+};
+
+exports.down = function (db, callback) {
+  db.runSql(`ALTER TABLE searches DROP COLUMN qhash;`, callback);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/migrations/20221016230508-searches-hash-uniq.js
+++ b/api/migrations/20221016230508-searches-hash-uniq.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  db.runSql(
+    `create unique index searches_uniq on searches (membership_id, destiny_version, qhash);`,
+    callback
+  );
+};
+
+exports.down = function (db, callback) {
+  db.runSql(`drop index searches_uniq;`, callback);
+};
+exports._meta = {
+  version: 1,
+};
+
+// TODO: drop existing indexes after updating queries

--- a/kubernetes/dim-api-hpa.yaml
+++ b/kubernetes/dim-api-hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: dim-api-hpa
@@ -8,9 +8,11 @@ spec:
     kind: Deployment
     name: dim-api
   minReplicas: 3
-  maxReplicas: 18
+  maxReplicas: 40
   metrics:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 60
+        target:
+          type: Utilization
+          averageUtilization: 60


### PR DESCRIPTION
This adds a new generated column (an md5 hash of the query) and a new unique index that uses that value instead of the query. Should be a lot faster and more compact than the current index.