### PR TITLE
Support tag variants in queries

### DIFF
--- a/api/db/item-annotations-queries.test.ts
+++ b/api/db/item-annotations-queries.test.ts
@@ -144,7 +144,7 @@ it('can insert tags with a variant', async () => {
   await transaction(async (client) => {
     await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
       id: '123456',
-      tag: 'favorite',
+      tag: 'keep',
       v: TagVariant.PVP,
     });
 
@@ -156,7 +156,7 @@ it('can insert tags with a variant', async () => {
     );
     expect(annotations[0]).toEqual({
       id: '123456',
-      tag: 'favorite',
+      tag: 'keep',
       v: TagVariant.PVP,
     });
 
@@ -174,7 +174,7 @@ it('can insert tags with a variant', async () => {
     );
     expect(annotations2[0]).toEqual({
       id: '123456',
-      tag: 'favorite',
+      tag: 'keep',
       v: TagVariant.PVP,
       notes: 'pretty cool',
     });

--- a/api/db/item-annotations-queries.test.ts
+++ b/api/db/item-annotations-queries.test.ts
@@ -1,10 +1,11 @@
-import { transaction, pool } from '.';
+import { pool, transaction } from '.';
+import { TagVariant } from '../shapes/item-annotations';
 import {
-  updateItemAnnotation,
-  getItemAnnotationsForProfile,
   deleteAllItemAnnotations,
   deleteItemAnnotation,
-  deleteItemAnnotationList
+  deleteItemAnnotationList,
+  getItemAnnotationsForProfile,
+  updateItemAnnotation,
 } from './item-annotations-queries';
 
 const appId = 'settings-queries-test-app';
@@ -21,18 +22,11 @@ afterAll(() => pool.end());
 
 it('can insert tags where none exist before', async () => {
   await transaction(async (client) => {
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: 'favorite',
-        notes: 'the best'
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'favorite',
+      notes: 'the best',
+    });
 
     const annotations = await getItemAnnotationsForProfile(
       client,
@@ -43,38 +37,24 @@ it('can insert tags where none exist before', async () => {
     expect(annotations[0]).toEqual({
       id: '123456',
       tag: 'favorite',
-      notes: 'the best'
+      notes: 'the best',
     });
   });
 });
 
 it('can update tags where none exist before', async () => {
   await transaction(async (client) => {
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: 'favorite',
-        notes: 'the best'
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'favorite',
+      notes: 'the best',
+    });
 
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: 'junk',
-        notes: 'the worst'
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'junk',
+      notes: 'the worst',
+    });
 
     const annotations = await getItemAnnotationsForProfile(
       client,
@@ -85,37 +65,23 @@ it('can update tags where none exist before', async () => {
     expect(annotations[0]).toEqual({
       id: '123456',
       tag: 'junk',
-      notes: 'the worst'
+      notes: 'the worst',
     });
   });
 });
 
 it('can update tags clearing value', async () => {
   await transaction(async (client) => {
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: 'favorite',
-        notes: 'the best'
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'favorite',
+      notes: 'the best',
+    });
 
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: null
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: null,
+    });
 
     const annotations = await getItemAnnotationsForProfile(
       client,
@@ -125,25 +91,18 @@ it('can update tags clearing value', async () => {
     );
     expect(annotations[0]).toEqual({
       id: '123456',
-      notes: 'the best'
+      notes: 'the best',
     });
   });
 });
 
 it('can delete tags', async () => {
   await transaction(async (client) => {
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: 'favorite',
-        notes: 'the best'
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'favorite',
+      notes: 'the best',
+    });
 
     await deleteItemAnnotation(client, bungieMembershipId, '123456');
 
@@ -159,31 +118,17 @@ it('can delete tags', async () => {
 
 it('can delete tags by setting both values to null/empty', async () => {
   await transaction(async (client) => {
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: 'favorite',
-        notes: 'the best'
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'favorite',
+      notes: 'the best',
+    });
 
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: null,
-        notes: ''
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: null,
+      notes: '',
+    });
 
     const annotations = await getItemAnnotationsForProfile(
       client,
@@ -195,37 +140,61 @@ it('can delete tags by setting both values to null/empty', async () => {
   });
 });
 
+it('can insert tags with a variant', async () => {
+  await transaction(async (client) => {
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'favorite',
+      v: TagVariant.PVP,
+    });
+
+    const annotations = await getItemAnnotationsForProfile(
+      client,
+      bungieMembershipId,
+      platformMembershipId,
+      2
+    );
+    expect(annotations[0]).toEqual({
+      id: '123456',
+      tag: 'favorite',
+      v: TagVariant.PVP,
+    });
+
+    // And updating notes doesn't mess with that:
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      notes: 'pretty cool',
+    });
+
+    const annotations2 = await getItemAnnotationsForProfile(
+      client,
+      bungieMembershipId,
+      platformMembershipId,
+      2
+    );
+    expect(annotations2[0]).toEqual({
+      id: '123456',
+      tag: 'favorite',
+      v: TagVariant.PVP,
+      notes: 'pretty cool',
+    });
+  });
+});
+
 it('can clear tags', async () => {
   await transaction(async (client) => {
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '123456',
-        tag: 'favorite',
-        notes: 'the best'
-      }
-    );
-    await updateItemAnnotation(
-      client,
-      appId,
-      bungieMembershipId,
-      platformMembershipId,
-      2,
-      {
-        id: '654321',
-        tag: 'junk',
-        notes: 'the worst'
-      }
-    );
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '123456',
+      tag: 'favorite',
+      notes: 'the best',
+    });
+    await updateItemAnnotation(client, appId, bungieMembershipId, platformMembershipId, 2, {
+      id: '654321',
+      tag: 'junk',
+      notes: 'the worst',
+    });
 
-    await deleteItemAnnotationList(client, bungieMembershipId, [
-      '123456',
-      '654321'
-    ]);
+    await deleteItemAnnotationList(client, bungieMembershipId, ['123456', '654321']);
 
     const annotations = await getItemAnnotationsForProfile(
       client,

--- a/api/db/item-annotations-queries.ts
+++ b/api/db/item-annotations-queries.ts
@@ -99,7 +99,7 @@ export async function updateItemAnnotation(
       text: `insert INTO item_annotations (membership_id, platform_membership_id, destiny_version, inventory_item_id, tag, notes, variant, crafted_date, created_by, last_updated_by)
 values ($1, $2, $3, $4, (CASE WHEN $5 = 'clear'::item_tag THEN NULL ELSE $5 END)::item_tag, (CASE WHEN $6 = 'clear' THEN NULL ELSE $6 END), $9, $8, $7, $7)
 on conflict (membership_id, inventory_item_id)
-do update set (tag, notes, variant, last_updated_at, last_updated_by) = ((CASE WHEN $5 = 'clear' THEN NULL WHEN $5 IS NULL THEN item_annotations.tag ELSE $5 END), (CASE WHEN $6 = 'clear' THEN NULL WHEN $6 IS NULL THEN item_annotations.notes ELSE $6 END), (CASE WHEN $9 = 'clear' THEN NULL WHEN $9 IS NULL THEN item_annotations.variant ELSE $9 END), current_timestamp, $7)`,
+do update set (tag, notes, variant, last_updated_at, last_updated_by) = ((CASE WHEN $5 = 'clear' THEN NULL WHEN $5 IS NULL THEN item_annotations.tag ELSE $5 END), (CASE WHEN $6 = 'clear' THEN NULL WHEN $6 IS NULL THEN item_annotations.notes ELSE $6 END), (CASE WHEN $9 = 0 THEN NULL WHEN $9 IS NULL THEN item_annotations.variant ELSE $9 END), current_timestamp, $7)`,
       values: [
         bungieMembershipId,
         platformMembershipId,
@@ -143,17 +143,17 @@ function clearValue<T extends string>(val: T | null | undefined): T | 'clear' | 
 /**
  * Like clearValue, this decides whether the variant should be set, cleared, or left alone.
  * Returning null preserves the existing value.
- * Returning "clear", removes the existing value,
+ * Returning 0, removes the existing value,
  */
 function variantValue(
   tag: TagValue | 'clear' | null,
   v: TagVariant | undefined
-): TagVariant | 'clear' | null {
+): TagVariant | 0 | null {
   if (tag === 'keep') {
-    return v ?? 'clear';
+    return v ?? 0;
   } else if (tag !== null) {
     // If tag is being cleared or set to a non-keep value, remove the variant
-    return 'clear';
+    return 0;
   } else {
     // Otherwise leave it be
     return null;

--- a/api/db/item-annotations-queries.ts
+++ b/api/db/item-annotations-queries.ts
@@ -1,7 +1,7 @@
 import { ClientBase, QueryResult } from 'pg';
 import { metrics } from '../metrics';
 import { DestinyVersion } from '../shapes/general';
-import { ItemAnnotation } from '../shapes/item-annotations';
+import { ItemAnnotation, TagValue, TagVariant } from '../shapes/item-annotations';
 
 /**
  * Get all of the item annotations for a particular platform_membership_id and destiny_version.
@@ -15,7 +15,7 @@ export async function getItemAnnotationsForProfile(
   try {
     const results = await client.query({
       name: 'get_item_annotations',
-      text: 'SELECT inventory_item_id, tag, notes, crafted_date FROM item_annotations WHERE membership_id = $1 and platform_membership_id = $2 and destiny_version = $3',
+      text: 'SELECT inventory_item_id, tag, notes, variant, crafted_date FROM item_annotations WHERE membership_id = $1 and platform_membership_id = $2 and destiny_version = $3',
       values: [bungieMembershipId, platformMembershipId, destinyVersion],
     });
     return results.rows.map(convertItemAnnotation);
@@ -41,7 +41,7 @@ export async function getAllItemAnnotationsForUser(
     // TODO: this isn't indexed!
     const results = await client.query({
       name: 'get_all_item_annotations',
-      text: 'SELECT platform_membership_id, destiny_version, inventory_item_id, tag, notes, crafted_date FROM item_annotations WHERE membership_id = $1',
+      text: 'SELECT platform_membership_id, destiny_version, inventory_item_id, tag, notes, variant, crafted_date FROM item_annotations WHERE membership_id = $1',
       values: [bungieMembershipId],
     });
     return results.rows.map((row) => ({
@@ -67,6 +67,9 @@ function convertItemAnnotation(row: any): ItemAnnotation {
   if (row.crafted_date) {
     result.craftedDate = row.crafted_date.getTime() / 1000;
   }
+  if (row.variant) {
+    result.v = row.variant;
+  }
   return result;
 }
 
@@ -82,6 +85,8 @@ export async function updateItemAnnotation(
   itemAnnotation: ItemAnnotation
 ): Promise<QueryResult<any>> {
   const tagValue = clearValue(itemAnnotation.tag);
+  // Variant will only be set when tag is set and only for "keep" values
+  const variant = variantValue(tagValue, itemAnnotation.v);
   const notesValue = clearValue(itemAnnotation.notes);
 
   if (tagValue === 'clear' && notesValue === 'clear') {
@@ -91,10 +96,10 @@ export async function updateItemAnnotation(
   try {
     const response = await client.query({
       name: 'upsert_item_annotation',
-      text: `insert INTO item_annotations (membership_id, platform_membership_id, destiny_version, inventory_item_id, tag, notes, crafted_date, created_by, last_updated_by)
-values ($1, $2, $3, $4, (CASE WHEN $5 = 'clear'::item_tag THEN NULL ELSE $5 END)::item_tag, (CASE WHEN $6 = 'clear' THEN NULL ELSE $6 END), $8, $7, $7)
+      text: `insert INTO item_annotations (membership_id, platform_membership_id, destiny_version, inventory_item_id, tag, notes, variant, crafted_date, created_by, last_updated_by)
+values ($1, $2, $3, $4, (CASE WHEN $5 = 'clear'::item_tag THEN NULL ELSE $5 END)::item_tag, (CASE WHEN $6 = 'clear' THEN NULL ELSE $6 END), $9, $8, $7, $7)
 on conflict (membership_id, inventory_item_id)
-do update set (tag, notes, last_updated_at, last_updated_by) = ((CASE WHEN $5 = 'clear' THEN NULL WHEN $5 IS NULL THEN item_annotations.tag ELSE $5 END), (CASE WHEN $6 = 'clear' THEN NULL WHEN $6 IS NULL THEN item_annotations.notes ELSE $6 END), current_timestamp, $7)`,
+do update set (tag, notes, variant, last_updated_at, last_updated_by) = ((CASE WHEN $5 = 'clear' THEN NULL WHEN $5 IS NULL THEN item_annotations.tag ELSE $5 END), (CASE WHEN $6 = 'clear' THEN NULL WHEN $6 IS NULL THEN item_annotations.notes ELSE $6 END), (CASE WHEN $9 = 'clear' THEN NULL WHEN $9 IS NULL THEN item_annotations.variant ELSE $9 END), current_timestamp, $7)`,
       values: [
         bungieMembershipId,
         platformMembershipId,
@@ -104,6 +109,7 @@ do update set (tag, notes, last_updated_at, last_updated_by) = ((CASE WHEN $5 = 
         notesValue,
         appId,
         itemAnnotation.craftedDate ? new Date(itemAnnotation.craftedDate * 1000) : null,
+        variant,
       ],
     });
 
@@ -124,13 +130,33 @@ do update set (tag, notes, last_updated_at, last_updated_by) = ((CASE WHEN $5 = 
  * If it's undefined we return null, which will preserve the existing value.
  * If it's set, we'll return the input which will update the existing value.
  */
-function clearValue(val: string | null | undefined) {
+function clearValue<T extends string>(val: T | null | undefined): T | 'clear' | null {
   if (val === null || (val !== undefined && val.length === 0)) {
     return 'clear';
   } else if (!val) {
     return null;
   } else {
     return val;
+  }
+}
+
+/**
+ * Like clearValue, this decides whether the variant should be set, cleared, or left alone.
+ * Returning null preserves the existing value.
+ * Returning "clear", removes the existing value,
+ */
+function variantValue(
+  tag: TagValue | 'clear' | null,
+  v: TagVariant | undefined
+): TagVariant | 'clear' | null {
+  if (tag === 'keep') {
+    return v ?? 'clear';
+  } else if (tag !== null) {
+    // If tag is being cleared or set to a non-keep value, remove the variant
+    return 'clear';
+  } else {
+    // Otherwise leave it be
+    return null;
   }
 }
 

--- a/api/migrations/20221224022935-item-annotations-variant.js
+++ b/api/migrations/20221224022935-item-annotations-variant.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  db.runSql(`ALTER TABLE item_annotations ADD COLUMN variant smallint;`, callback);
+};
+
+exports.down = function (db, callback) {
+  db.runSql(`ALTER TABLE item_annotations DROP COLUMN variant;`, callback);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/shapes/item-annotations.ts
+++ b/api/shapes/item-annotations.ts
@@ -1,6 +1,6 @@
 export type TagValue = 'favorite' | 'keep' | 'infuse' | 'junk' | 'archive';
 
-enum TagVariant {
+export enum TagVariant {
   PVP = 1,
   PVE = 2,
 }


### PR DESCRIPTION
This allows tag variants (pvp, pve) to be saved and queried from the API.