### PR TITLE
Add Google Analytics to dim.gg share pages

### DIFF
--- a/api/dim-gg/views/loadout.ejs
+++ b/api/dim-gg/views/loadout.ejs
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-M2CXWQ23SV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-M2CXWQ23SV');
+    </script>
     <meta charset="utf-8" />
     <title><%= loadout.name %> | DIM Loadout</title>
     <meta name="description" content="<%= description %>" />


### PR DESCRIPTION
This should give us an easy way to find popular loadouts and where they're coming from.