### PR TITLE
Start storing profile IDs in JWT

### DIFF
--- a/api/global.d.ts
+++ b/api/global.d.ts
@@ -1,13 +1,10 @@
+import { JwtPayload } from 'jsonwebtoken';
 import { ApiApp } from './shapes/app';
 import { UserInfo } from './shapes/user';
 
 declare module 'express-serve-static-core' {
   interface Request {
-    jwt?: {
-      sub: string;
-      iss: string;
-      exp: number;
-    };
+    jwt?: JwtPayload;
 
     user?: UserInfo;
 

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -30,7 +30,12 @@ import {
   UsedSearchUpdate,
 } from '../shapes/profile';
 import { Settings } from '../shapes/settings';
-import { badRequest, isValidItemId, isValidPlatformMembershipId } from '../utils';
+import {
+  badRequest,
+  checkPlatformMembershipId,
+  isValidItemId,
+  isValidPlatformMembershipId,
+} from '../utils';
 
 /**
  * Update profile information. This accepts a list of update operations and
@@ -39,7 +44,7 @@ import { badRequest, isValidItemId, isValidPlatformMembershipId } from '../utils
  * Note that you can't mix updates for multiple profiles - you'll have to make multiple requests.
  */
 export const updateHandler = asyncHandler(async (req, res) => {
-  const { bungieMembershipId } = req.user!;
+  const { bungieMembershipId, profileIds } = req.user!;
   const { id: appId } = req.dimApp!;
   metrics.increment('update.app.' + appId, 1);
   const request = req.body as ProfileUpdateRequest;
@@ -50,6 +55,8 @@ export const updateHandler = asyncHandler(async (req, res) => {
     badRequest(res, `platformMembershipId ${platformMembershipId} is not in the right format`);
     return;
   }
+
+  checkPlatformMembershipId(platformMembershipId, profileIds, 'update');
 
   if (destinyVersion !== 1 && destinyVersion !== 2) {
     badRequest(res, `destinyVersion ${destinyVersion} is not in the right format`);

--- a/api/server.ts
+++ b/api/server.ts
@@ -101,8 +101,9 @@ app.use((req, _, next) => {
     next(new Error('Expected JWT info'));
   } else {
     req.user = {
-      bungieMembershipId: parseInt(req.jwt.sub, 10),
-      dimApiKey: req.jwt.iss,
+      bungieMembershipId: parseInt(req.jwt.sub!, 10),
+      dimApiKey: req.jwt.iss!,
+      profileIds: req.jwt['profileIds'] ?? [],
     };
     next();
   }

--- a/api/shapes/user.ts
+++ b/api/shapes/user.ts
@@ -3,4 +3,6 @@ export interface UserInfo {
   bungieMembershipId: number;
   /** The DIM App API key this token was issued for */
   dimApiKey: string;
+  /** A list of Destiny 2 membership profiles this account can access. */
+  profileIds: string[];
 }


### PR DESCRIPTION
Part one of fixing #141. This changes to storing the list of profile IDs (primary profile ID first) in the JWT for newly minted tokens. It should take a month for these to rotate in. In the meantime I'll just log metrics about them.

The idea is that once these have all gotten set, we can switch our authorization checks to use that list instead of the Bungie.net membership ID, and remove membership ID from the profile-specific tables.