### PR TITLE
Clean out loadout shape and add separated clear-out settings

### DIFF
--- a/api/shapes/loadouts.ts
+++ b/api/shapes/loadouts.ts
@@ -43,9 +43,15 @@ export interface Loadout {
   classType: DestinyClass;
   /**
    * DestinyInventoryItemDefinition hash of an emblem to use as
-   * an icon for this loadout
+   * an icon for this loadout.
+   *
+   * @deprecated this was added for Little Light but never used by DIM.
    */
   emblemHash?: number;
+  /**
+   * Whether to clear out other items when applying this loadout
+   * @deprecated in favor of parameters.clearWeapons and parameters.clearArmor
+   */
   /** Whether to clear out other items when applying this loadout */
   clearSpace: boolean;
   /** List of equipped items in the loadout */
@@ -64,28 +70,10 @@ export interface Loadout {
    * out all over again every time (especially since our algorithm might
    * change). Combine this list and parameters.mods when displaying or actually
    * applying the loadout.
+   *
+   * @deprecated we just throw away stat mods when using LO auto stats
    */
   autoStatMods?: number[];
-  /**
-   * a user may optionally specify which icon/color/name will be used,
-   * if this DIM loadout is saved to an in-game slot
-   */
-  inGameIdentifiers?: InGameLoadoutIdentifiers;
-}
-
-/** The level of upgrades the user is willing to perform in order to fit mods into their loadout or hit stats. */
-export const enum UpgradeSpendTier {
-  Nothing,
-  LegendaryShards,
-  EnhancementPrisms,
-  AscendantShardsNotExotic,
-  AscendantShards,
-  AscendantShardsNotMasterworked,
-  /**
-   * @deprecated
-   * No longer needed with the lock energy toggle, treat this as if it was the Nothing option.
-   */
-  AscendantShardsLockEnergyType,
 }
 
 /** Whether armor of this type will have assumed masterworked stats in the Loadout Optimizer. */
@@ -95,20 +83,6 @@ export const enum AssumeArmorMasterwork {
   /** Only legendary armor will have assumed masterworked stats. */
   Legendary,
   /** All armor (legendary & exotic) will have assumed masterworked stats. */
-  All,
-}
-
-/**
- * Whether armor of this type will have locked energy type in the Loadout Optimizer.
- * @deprecated
- * Armor energy type does not exist anymore.
- */
-export const enum LockArmorEnergyType {
-  /** No armor will have their energy type locked. */
-  None = 1,
-  /** Only already masterworked armor will have their energy type locked. */
-  Masterworked,
-  /** All armor will have their energy type locked. */
   All,
 }
 
@@ -124,6 +98,11 @@ export const enum LoadoutSort {
  * This can be used to re-load a loadout into Loadout Optimizer with its
  * settings intact, or to equip the right mods when applying a loadout if AWA is
  * ever released.
+ *
+ * Originally this was meant to model parameters independent of specific items,
+ * as a means of sharing Loadout Optimizer settings between users, but now we
+ * just share whole loadouts, so this can be used for any sort of parameter we
+ * want to add to loadouts.
  *
  * All properties are optional, but most have defaults specified in
  * defaultLoadoutParameters that should be used if they are undefined.
@@ -150,6 +129,12 @@ export interface LoadoutParameters {
    * If set, after applying the mods above, all other mods will be removed from armor.
    */
   clearMods?: boolean;
+
+  /** Whether to clear out other weapons when applying this loadout */
+  clearWeapons?: boolean;
+
+  /** Whether to clear out other weapons when applying this loadout */
+  clearArmor?: boolean;
 
   /**
    * Mods that must be applied to a specific bucket hash. In general, prefer to
@@ -182,21 +167,6 @@ export interface LoadoutParameters {
   query?: string;
 
   /**
-   * When generating the loadout, did we assume all items were at their
-   * masterworked stats, or did we use their current stats?
-   *
-   * @deprecated use assumeArmorMasterworked
-   */
-  assumeMasterworked?: boolean;
-
-  /**
-   * What upgrades are the user willing to shell out for?
-   *
-   * @deprecated use assumeArmorMasterworked
-   */
-  upgradeSpendTier?: UpgradeSpendTier;
-
-  /**
    * Whether armor of this type will have assumed materwork stats in the Loadout Optimizer.
    */
   assumeArmorMasterwork?: AssumeArmorMasterwork;
@@ -207,17 +177,10 @@ export interface LoadoutParameters {
   exoticArmorHash?: number;
 
   /**
-   * Don't change energy type of armor in order to fit mods.
-   *
-   * @deprecated use lockArmorEnergyType
+   * a user may optionally specify which icon/color/name will be used,
+   * if this DIM loadout is saved to an in-game slot
    */
-  lockItemEnergyType?: boolean;
-
-  /**
-   * Whether armor of this type will have locked energy type in the Loadout Optimizer.
-   * @deprecated Armor energy type does not exist anymore.
-   */
-  lockArmorEnergyType?: LockArmorEnergyType;
+  inGameIdentifiers?: InGameLoadoutIdentifiers;
 }
 
 /**
@@ -236,7 +199,6 @@ export const defaultLoadoutParameters: LoadoutParameters = {
   ],
   mods: [],
   assumeArmorMasterwork: AssumeArmorMasterwork.None,
-  lockArmorEnergyType: LockArmorEnergyType.None,
   autoStatMods: true,
 };
 


### PR DESCRIPTION
1. Remove some long-deprecated settings
2. Move the "clear items" setting into LoadoutParameters and separate it into weapons and armor settings.
3. Move `inGameIdentifiers` into LoadoutParameters so it'll actually be saved in the database.
4. Deprecate some stuff we never used.
5. Add/update some documentation.