### PR TITLE
Update expiration headers for profile

### DIFF
--- a/api/routes/export.ts
+++ b/api/routes/export.ts
@@ -31,6 +31,6 @@ export const exportHandler = asyncHandler(async (req, res) => {
   });
 
   // Instruct CF not to cache this
-  res.set('Cache-Control', 'no-cache, max-age=0');
+  res.set('Cache-Control', 'no-cache, no-store, max-age=0');
   res.send(response);
 });

--- a/api/routes/platform-info.ts
+++ b/api/routes/platform-info.ts
@@ -17,7 +17,7 @@ export const platformInfoHandler = asyncHandler(async (req, res) => {
       : defaultGlobalSettings;
 
   // Instruct CF to cache for 15 minutes
-  res.set('Cache-Control', 'max-age=900');
+  res.set('Cache-Control', 'public, max-age=900');
   res.send({
     settings,
   });

--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -168,6 +168,7 @@ export const profileHandler = asyncHandler(async (req, res) => {
   });
 
   // Instruct CF not to cache this for longer than a minute
-  res.set('Cache-Control', 'max-age=60');
+  res.set('Cache-Control', 'public, max-age=60');
+  res.set('Expires', new Date(Date.now() + 60 * 1000).toUTCString());
   res.send(response);
 });


### PR DESCRIPTION
We've seen weird reports of people keeping cached responses for API calls. This shouldn't be happening since we set `maxage=60` so the responses should be quickly stale. Regardless, I figured we could maybe add an `Expires` header even though it's supposed to be ignored when `maxage` is present.