### PR TITLE
Disable tag_cleanup

### DIFF
--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -2,7 +2,7 @@ import asyncHandler from 'express-async-handler';
 import { ClientBase } from 'pg';
 import { transaction } from '../db/index.js';
 import {
-  deleteItemAnnotationList,
+  // deleteItemAnnotationList,
   updateItemAnnotation as updateItemAnnotationInDb,
 } from '../db/item-annotations-queries.js';
 import { updateItemHashTag as updateItemHashTagInDb } from '../db/item-hash-tags-queries.js';

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -362,17 +362,18 @@ async function updateItemAnnotation(
 }
 
 async function tagCleanup(
-  client: ClientBase,
-  bungieMembershipId: number,
-  inventoryItemIds: string[],
+  _client: ClientBase,
+  _bungieMembershipId: number,
+  _inventoryItemIds: string[],
 ): Promise<ProfileUpdateResult> {
-  const start = new Date();
-  await deleteItemAnnotationList(
-    client,
-    bungieMembershipId,
-    inventoryItemIds.filter(isValidItemId),
-  );
-  metrics.timing('update.tagCleanup', start);
+  // TEMPORARY: Disable tag cleanup while bungie.net is being weird
+  //const start = new Date();
+  //await deleteItemAnnotationList(
+  //  client,
+  //  bungieMembershipId,
+  //  inventoryItemIds.filter(isValidItemId),
+  //);
+  //metrics.timing('update.tagCleanup', start);
 
   return { status: 'Success' };
 }


### PR DESCRIPTION
Edited from the GitHub UI so not sure if it'll work, but this neuters tag_cleanup while we investigate bungie.net issues.