### PR TITLE
Track the type of saved searches

### DIFF
--- a/api/db/apps-queries.test.ts
+++ b/api/db/apps-queries.test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { ApiApp } from '../shapes/app.js';
 import { getAllApps, getAppById, insertApp } from './apps-queries.js';
-import { pool, transaction } from './index.js';
+import { closeDbPool, pool, transaction } from './index.js';
 
 const appId = 'apps-queries-test-app';
 const app: ApiApp = {
@@ -13,7 +13,7 @@ const app: ApiApp = {
 
 beforeEach(() => pool.query({ text: 'delete from apps where id = $1', values: [appId] }));
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 it('can create a new app', async () => {
   await transaction(async (client) => {

--- a/api/db/index.test.ts
+++ b/api/db/index.test.ts
@@ -1,4 +1,4 @@
-import { pool, readTransaction, transaction } from './index.js';
+import { closeDbPool, pool, readTransaction, transaction } from './index.js';
 
 beforeEach(async () => {
   try {
@@ -14,7 +14,7 @@ afterAll(async () => {
   try {
     await pool.query(`DROP TABLE transaction_test`);
   } catch {}
-  await pool.end();
+  await closeDbPool();
 });
 
 describe('transaction', () => {

--- a/api/db/index.ts
+++ b/api/db/index.ts
@@ -27,11 +27,16 @@ pool.on('remove', () => {
   metrics.increment('db.pool.remove.count');
 });
 
-setInterval(() => {
+const metricsInterval = setInterval(() => {
   metrics.gauge('db.pool.total', pool.totalCount);
   metrics.gauge('db.pool.idle', pool.idleCount);
   metrics.gauge('db.pool.waiting', pool.waitingCount);
 }, 10000);
+
+export async function closeDbPool() {
+  clearInterval(metricsInterval);
+  return pool.end();
+}
 
 /**
  * A helper that gets a connection from the pool and then executes fn within a transaction.

--- a/api/db/item-annotations-queries.test.ts
+++ b/api/db/item-annotations-queries.test.ts
@@ -1,5 +1,5 @@
 import { TagVariant } from '../shapes/item-annotations.js';
-import { pool, transaction } from './index.js';
+import { closeDbPool, transaction } from './index.js';
 import {
   deleteAllItemAnnotations,
   deleteItemAnnotation,
@@ -18,7 +18,7 @@ beforeEach(() =>
   }),
 );
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 it('can insert tags where none exist before', async () => {
   await transaction(async (client) => {

--- a/api/db/item-hash-tags-queries.test.ts
+++ b/api/db/item-hash-tags-queries.test.ts
@@ -1,4 +1,4 @@
-import { pool, transaction } from './index.js';
+import { closeDbPool, transaction } from './index.js';
 import {
   deleteAllItemHashTags,
   deleteItemHashTag,
@@ -15,7 +15,7 @@ beforeEach(() =>
   }),
 );
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 it('can insert item hash tags where none exist before', async () => {
   await transaction(async (client) => {

--- a/api/db/loadout-share-queries.test.ts
+++ b/api/db/loadout-share-queries.test.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { Loadout, LoadoutItem } from '../shapes/loadouts.js';
-import { pool, transaction } from './index.js';
+import { closeDbPool, transaction } from './index.js';
 import { addLoadoutShare, getLoadoutShare, recordAccess } from './loadout-share-queries.js';
 
 const appId = 'settings-queries-test-app';
@@ -15,7 +15,7 @@ beforeEach(() =>
   }),
 );
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 const loadout: Loadout = {
   id: uuid(),

--- a/api/db/loadouts-queries.test.ts
+++ b/api/db/loadouts-queries.test.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { Loadout, LoadoutItem } from '../shapes/loadouts.js';
-import { pool, transaction } from './index.js';
+import { closeDbPool, transaction } from './index.js';
 import { deleteLoadout, getLoadoutsForProfile, updateLoadout } from './loadouts-queries.js';
 
 const appId = 'settings-queries-test-app';
@@ -13,7 +13,7 @@ beforeEach(() =>
   }),
 );
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 const loadout: Loadout = {
   id: uuid(),

--- a/api/db/searches-queries.test.ts
+++ b/api/db/searches-queries.test.ts
@@ -1,5 +1,5 @@
 import { SearchType } from '../shapes/search.js';
-import { pool, transaction } from './index.js';
+import { closeDbPool, transaction } from './index.js';
 import {
   deleteAllSearches,
   deleteSearch,
@@ -19,7 +19,7 @@ beforeEach(() =>
   }),
 );
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 it('can record a used search where none was recorded before', async () => {
   await transaction(async (client) => {

--- a/api/db/searches-queries.ts
+++ b/api/db/searches-queries.ts
@@ -50,7 +50,7 @@ export async function getSearchesForProfile(
     const results = await client.query({
       name: 'get_searches',
       // TODO: order by frecency
-      text: 'SELECT query, saved, usage_count, last_updated_at FROM searches WHERE membership_id = $1 and destiny_version = $2 order by last_updated_at DESC, usage_count DESC LIMIT 500',
+      text: 'SELECT query, saved, usage_count, search_type, last_updated_at FROM searches WHERE membership_id = $1 and destiny_version = $2 order by last_updated_at DESC, usage_count DESC LIMIT 500',
       values: [bungieMembershipId, destinyVersion],
     });
     return _.uniqBy(
@@ -75,7 +75,7 @@ export async function getSearchesForUser(
   try {
     const results = await client.query({
       name: 'get_all_searches',
-      text: 'SELECT destiny_version, query, saved, usage_count, last_updated_at FROM searches WHERE membership_id = $1',
+      text: 'SELECT destiny_version, query, saved, usage_count, search_type, last_updated_at FROM searches WHERE membership_id = $1',
       values: [bungieMembershipId],
     });
     return results.rows.map((row) => ({

--- a/api/db/searches-queries.ts
+++ b/api/db/searches-queries.ts
@@ -116,7 +116,7 @@ export async function updateUsedSearch(
       text: `insert INTO searches (membership_id, destiny_version, query, search_type, created_by, last_updated_by)
 values ($1, $2, $3, $5, $4, $4)
 on conflict (membership_id, destiny_version, qhash)
-do update set (usage_count, last_used, last_updated_at, last_updated_by) = (searches.usage_count + 1, current_timestamp, current_timestamp, $5, $4)`,
+do update set (usage_count, last_used, last_updated_at, last_updated_by) = (searches.usage_count + 1, current_timestamp, current_timestamp, $4)`,
       values: [bungieMembershipId, destinyVersion, query, appId, type],
     });
 

--- a/api/db/settings-queries.test.ts
+++ b/api/db/settings-queries.test.ts
@@ -1,10 +1,10 @@
-import { pool, transaction } from './index.js';
+import { closeDbPool, transaction } from './index.js';
 import { getSettings, setSetting } from './settings-queries.js';
 
 const appId = 'settings-queries-test-app';
 const bungieMembershipId = 4321;
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 it('can insert settings where none exist before', async () => {
   await transaction(async (client) => {

--- a/api/db/triumphs-queries.test.ts
+++ b/api/db/triumphs-queries.test.ts
@@ -1,4 +1,4 @@
-import { pool, transaction } from './index.js';
+import { closeDbPool, transaction } from './index.js';
 import {
   deleteAllTrackedTriumphs,
   getAllTrackedTriumphsForUser,
@@ -17,7 +17,7 @@ beforeEach(() =>
   }),
 );
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 it('can track a triumph where none was tracked before', async () => {
   await transaction(async (client) => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -6,7 +6,7 @@ import http from 'http';
 import morgan from 'morgan';
 import vhost from 'vhost';
 import { refreshApps, stopAppsRefresh } from './apps/index.js';
-import { pool } from './db/index.js';
+import { closeDbPool } from './db/index.js';
 import { app as dimGgApp } from './dim-gg/server.js';
 import { metrics } from './metrics/index.js';
 import { app as dimApiApp } from './server.js';
@@ -123,7 +123,7 @@ createTerminus(server, {
   onShutdown: async () => {
     console.log('Shutting down');
     stopAppsRefresh();
-    pool.end();
+    closeDbPool();
   },
 });
 

--- a/api/migrations/20240521044000-add-search-type.js
+++ b/api/migrations/20240521044000-add-search-type.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  db.runSql(`ALTER TABLE searches ADD COLUMN search_type smallint NOT NULL DEFAULT 1;`, callback);
+};
+
+exports.down = function (db, callback) {
+  db.runSql(`ALTER TABLE searches DROP COLUMN search_type;`, callback);
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/routes/import.ts
+++ b/api/routes/import.ts
@@ -12,6 +12,7 @@ import { DestinyVersion } from '../shapes/general.js';
 import { ImportResponse } from '../shapes/import.js';
 import { ItemAnnotation } from '../shapes/item-annotations.js';
 import { Loadout } from '../shapes/loadouts.js';
+import { SearchType } from '../shapes/search.js';
 import { defaultSettings, Settings } from '../shapes/settings.js';
 import { badRequest } from '../utils.js';
 import { deleteAllData } from './delete-all-data.js';
@@ -123,6 +124,7 @@ export const importHandler = asyncHandler(async (req, res) => {
         search.search.saved,
         search.search.lastUsage,
         search.search.usageCount,
+        search.search.type ?? SearchType.Item,
       );
     }
   });

--- a/api/server.test.ts
+++ b/api/server.test.ts
@@ -5,7 +5,7 @@ import supertest from 'supertest';
 import { promisify } from 'util';
 import { v4 as uuid } from 'uuid';
 import { refreshApps } from './apps/index.js';
-import { pool } from './db/index.js';
+import { closeDbPool } from './db/index.js';
 import { app } from './server.js';
 import { ExportResponse } from './shapes/export.js';
 import { GlobalSettings } from './shapes/global-settings.js';
@@ -34,7 +34,7 @@ beforeAll(async () => {
   });
 });
 
-afterAll(() => pool.end());
+afterAll(() => closeDbPool());
 
 it('returns basic info from GET /', async () => {
   // Sends GET Request to / endpoint

--- a/api/server.test.ts
+++ b/api/server.test.ts
@@ -12,6 +12,7 @@ import { GlobalSettings } from './shapes/global-settings.js';
 import { LoadoutShareRequest } from './shapes/loadout-share.js';
 import { Loadout, LoadoutItem } from './shapes/loadouts.js';
 import { ProfileResponse, ProfileUpdateRequest } from './shapes/profile.js';
+import { SearchType } from './shapes/search.js';
 import { defaultSettings } from './shapes/settings.js';
 
 const request = supertest(app);
@@ -891,6 +892,7 @@ describe('searches', () => {
           action: 'search',
           payload: {
             query: 'tag:favorite',
+            type: SearchType.Item,
           },
         },
       ],
@@ -920,12 +922,14 @@ describe('searches', () => {
           action: 'search',
           payload: {
             query: 'tag:favorite',
+            type: SearchType.Item,
           },
         },
         {
           action: 'save_search',
           payload: {
             query: 'tag:favorite',
+            type: SearchType.Item,
             saved: true,
           },
         },

--- a/api/shapes/profile.ts
+++ b/api/shapes/profile.ts
@@ -1,7 +1,7 @@
 import { DestinyVersion } from './general.js';
 import { ItemAnnotation, ItemHashTag } from './item-annotations.js';
 import { Loadout } from './loadouts.js';
-import { Search } from './search.js';
+import { Search, SearchType } from './search.js';
 import { Settings } from './settings.js';
 
 export interface ProfileResponse {
@@ -87,6 +87,7 @@ export interface UsedSearchUpdate {
   action: 'search';
   payload: {
     query: string;
+    type: SearchType;
   };
 }
 
@@ -97,6 +98,7 @@ export interface SavedSearchUpdate {
   action: 'save_search';
   payload: {
     query: string;
+    type: SearchType;
     /**
      * Whether the search should be saved
      */
@@ -111,6 +113,7 @@ export interface DeleteSearchUpdate {
   action: 'delete_search';
   payload: {
     query: string;
+    type: SearchType;
   };
 }
 

--- a/api/shapes/search.ts
+++ b/api/shapes/search.ts
@@ -1,3 +1,8 @@
+export const enum SearchType {
+  Item = 1,
+  Loadout = 2,
+}
+
 /**
  * A search query. This can either be from history (recent searches), pinned (saved searches), or suggested.
  */
@@ -15,4 +20,9 @@ export interface Search {
    * The last time this was used, as a unix millisecond timestamp.
    */
   lastUsage: number;
+  /**
+   * Which kind of thing is this search for? Searches of different types are
+   * stored together and need to be filtered to the specific type.
+   */
+  type: SearchType;
 }


### PR DESCRIPTION
This adds a `search_type` column to saved searches, so that we can store Loadout searches alongside Item searches. DIM will have to filter them by type once it gets them, but this seems like the fewest changes to allow for saving different search types.