### PR TITLE
Allow stale reads of global settings

### DIFF
--- a/api/routes/platform-info.ts
+++ b/api/routes/platform-info.ts
@@ -11,7 +11,9 @@ export const platformInfoHandler = asyncHandler(async (req, res) => {
   let settings: GlobalSettings | undefined = undefined;
   try {
     // Try StatelyDB first, then fall back to Postgres
-    const statelySettings = await client.get('GlobalSettings', keyPath`/gs-${flavor}`);
+    const statelySettings = await client
+      .withAllowStale(true)
+      .get('GlobalSettings', keyPath`/gs-${flavor}`);
     if (statelySettings) {
       settings = {
         ...statelySettings,


### PR DESCRIPTION
We can handle slightly stale reads of global settings, and it'll be cheaper without them.