### PR TITLE
Default profile ID if missing (for now)

### DIFF
--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -151,7 +151,7 @@ export const updateHandler = asyncHandler(async (req, res) => {
           req,
           updates,
           bungieMembershipId,
-          platformMembershipId,
+          platformMembershipId ?? profileIds[0],
           destinyVersion,
           appId,
         );
@@ -171,7 +171,7 @@ export const updateHandler = asyncHandler(async (req, res) => {
         req,
         updates,
         bungieMembershipId,
-        platformMembershipId,
+        platformMembershipId ?? profileIds[0],
         destinyVersion,
         appId,
       );

--- a/api/stately/schema/search.ts
+++ b/api/stately/schema/search.ts
@@ -30,7 +30,7 @@ export const Search = itemType('Search', {
     /**
      * The full search query. These are
      */
-    query: { type: string, fieldNum: 1, valid: 'this.size() <= 2048' },
+    query: { type: string, fieldNum: 1 },
     /** A zero usage count means this is a suggested/preloaded search. */
     usageCount: { type: uint32, fieldNum: 2, required: false },
     /** Has this search been saved/favorite'd/pinned by the user? */

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 import { pathsToModuleNameMapper } from 'ts-jest';
 import tsConfig from './tsconfig.json' with { type: 'json' };
 export default {
-  testTimeout: 10000,
+  testTimeout: 15000,
   transform: {
     '\\.ts$': [
       'ts-jest',


### PR DESCRIPTION
DIM isn't sending profile ID with searches yet, but we're storing them under profiles now. This defaults it to the one from the token.