### PR TITLE
Log out users who need to update their auth token

### DIFF
--- a/api/routes/loadout-share.ts
+++ b/api/routes/loadout-share.ts
@@ -67,6 +67,7 @@ export const loadoutShareHandler = asyncHandler(async (req, res) => {
     shareId = generateRandomShareId();
     try {
       await addLoadoutShareStately(platformMembershipId, shareId, loadout);
+      break;
     } catch (e) {
       // This is a unique constraint violation, generate another random share ID
       if (e instanceof LoadoutShareCollision) {

--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -48,10 +48,11 @@ export const profileHandler = asyncHandler(async (req, res) => {
   }
 
   if (!checkPlatformMembershipId(platformMembershipId, profileIds)) {
-    badRequest(
-      res,
-      `platformMembershipId ${platformMembershipId} is not one of the profiles associated with this user's Bungie.net account`,
-    );
+    // This should force a re-auth
+    res.status(401).send({
+      error: 'UnknownProfileId',
+      message: `platformMembershipId ${platformMembershipId} is not one of the profiles associated with your Bungie.net account. Try logging out and logging back in.`,
+    });
     return;
   }
 

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -91,10 +91,11 @@ export const updateHandler = asyncHandler(async (req, res) => {
   }
 
   if (!checkPlatformMembershipId(platformMembershipId, profileIds)) {
-    badRequest(
-      res,
-      `platformMembershipId ${platformMembershipId} is not one of the profiles associated with this user's Bungie.net account`,
-    );
+    // This should force a re-auth
+    res.status(401).send({
+      error: 'UnknownProfileId',
+      message: `platformMembershipId ${platformMembershipId} is not one of the profiles associated with your Bungie.net account. Try logging out and logging back in.`,
+    });
     return;
   }
 

--- a/api/stately/loadouts-queries.ts
+++ b/api/stately/loadouts-queries.ts
@@ -273,8 +273,6 @@ export function convertLoadoutCommonFieldsToStately(
     classType: loadout.classType as number,
     equipped: (loadout.equipped || []).map(convertLoadoutItemToStately),
     unequipped: (loadout.unequipped || []).map(convertLoadoutItemToStately),
-    createdAt: BigInt(loadout.createdAt ?? 0),
-    lastUpdatedAt: BigInt(loadout.lastUpdatedAt ?? 0),
     notes: loadout.notes,
     parameters: convertLoadoutParametersToStately(loadout.parameters),
   };

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,4 @@
 export NODE_ENV="production"
 
 # Use "exec" so we inherit signals
-exec node api/index.js --async-stack-traces --experimental-json-modules
+exec node api/index.js --async-stack-traces --experimental-json-modules --enable-source-maps


### PR DESCRIPTION
We are now enforcing that the auth token must contain the profile you're interacting with. This returns a 401 if you don't, which at least will force DIM to re-auth.