### PR TITLE
Preserve timestamps

### DIFF
--- a/api/routes/loadout-share.ts
+++ b/api/routes/loadout-share.ts
@@ -54,7 +54,7 @@ export const loadoutShareHandler = asyncHandler(async (req, res) => {
     });
   }
 
-  const validationResult = validateLoadout('loadout_share', loadout, appId);
+  const validationResult = validateLoadout('loadout_share', loadout);
   if (validationResult) {
     res.status(400).send(validationResult);
     return;

--- a/api/routes/update.ts
+++ b/api/routes/update.ts
@@ -154,6 +154,7 @@ export const updateHandler = asyncHandler(async (req, res) => {
       triumphs,
       searches,
       itemHashTags,
+      !migrationState.lastError,
     );
   };
 
@@ -232,7 +233,7 @@ function validateUpdates(
         break;
 
       case 'loadout':
-        result = validateUpdateLoadout(update.payload, appId);
+        result = validateUpdateLoadout(update.payload);
         break;
 
       case 'tag':
@@ -514,11 +515,11 @@ async function updateLoadout(
   metrics.timing('update.loadout', start);
 }
 
-function validateUpdateLoadout(loadout: Loadout, appId: string): ProfileUpdateResult {
-  return validateLoadout('update', loadout, appId) ?? { status: 'Success' };
+function validateUpdateLoadout(loadout: Loadout): ProfileUpdateResult {
+  return validateLoadout('update', loadout) ?? { status: 'Success' };
 }
 
-export function validateLoadout(metricPrefix: string, loadout: Loadout, appId: string) {
+export function validateLoadout(metricPrefix: string, loadout: Loadout) {
   if (!loadout.name) {
     metrics.increment(`${metricPrefix}.validation.loadoutNameMissing.count`);
     return {


### PR DESCRIPTION
This preserves loadout timestamps on migration. It also uses `mustNotExist` conditions to remove the need to delete existing data before migration.