### PR TITLE
Set up NPM trusted publishing, remove CJS version of types

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,6 +47,4 @@ jobs:
 
       - name: Publish the package to NPM
         if: steps.check.outputs.changed == 'true'
-        run: cd dim-api-types && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # NPM will automatically authenticate with this
+        run: cd dim-api-types && npm publish --access public --provenance

--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -298,6 +298,7 @@ async function statelyProfile(
       extra: { syncToken: response.syncToken },
     });
   }
+  metrics.increment(response.sync ? `profile.response.sync` : `profile.response.full`, 1);
   return response;
 }
 

--- a/api/stately/bulk-queries.ts
+++ b/api/stately/bulk-queries.ts
@@ -190,7 +190,7 @@ async function exportDataForProfile(platformMembershipId: string): Promise<Expor
 export async function getProfile(
   platformMembershipId: string | bigint,
   destinyVersion: DestinyVersion,
-  suffix?: string,
+  suffix: string,
 ): Promise<{ profile: ProfileResponse; token: ListToken }> {
   const prefix = keyPath`/p-${BigInt(platformMembershipId)}/d-${destinyVersion}` + suffix;
 

--- a/api/stately/generated/README.md
+++ b/api/stately/generated/README.md
@@ -1,0 +1,25 @@
+# Schema Info
+
+This is an auto-generated README file to help you understand your schema!
+
+* SchemaID => `8030842688320564`
+* Schema Version => `8`
+* See schema on the [Stately Console](https://console.stately.cloud/1org/schemas/8030842688320564).
+
+### Key Path Layout
+
+| Group             | Key Path             | Item Type      | primary | required | syncable | txn type |
+|:------------------|:---------------------|:---------------|:--------|:---------|:---------|:---------|
+| `/apps-*`         | `/apps-*/app-*`      | ApiApp         | Yes     | Yes      | Yes      | group    |
+| `/gs-*`           | `/gs-*`              | GlobalSettings | Yes     | Yes      | Yes      | group    |
+| `/loadoutShare-*` | `/loadoutShare-*`    | LoadoutShare   | Yes     | Yes      | Yes      | group    |
+| `/member-*`       | `/member-*/settings` | Settings       | Yes     | Yes      | Yes      | group    |
+| `/p-*`            | `/p-*/d-*/ia-*`      | ItemAnnotation | Yes     | Yes      | Yes      | group    |
+| `/p-*`            | `/p-*/d-*/iht-*`     | ItemHashTag    | Yes     | Yes      | Yes      | group    |
+| `/p-*`            | `/p-*/d-*/loadout-*` | Loadout        | Yes     | Yes      | Yes      | group    |
+| `/p-*`            | `/p-*/d-*/search-*`  | Search         | Yes     | Yes      | Yes      | group    |
+| `/p-*`            | `/p-*/d-*/triumph-*` | Triumph        | Yes     | Yes      | Yes      | group    |
+
+### TODO:
+
+What else should we add here? Let us know!

--- a/api/stately/loadouts-queries.ts
+++ b/api/stately/loadouts-queries.ts
@@ -314,8 +314,8 @@ export function statConstraintsToStately(statConstraints: StatConstraint[] | und
         statHash: c.statHash,
         minTier: Math.max(0, Math.floor(c.minTier ?? 0)),
         maxTier: Math.min(Math.ceil(c.maxTier ?? 10), 10),
-        minStat: Math.max(0, Math.floor(c.minStat ?? 0)),
-        maxStat: Math.min(Math.ceil(c.maxStat ?? 200), 200),
+        minStat: Math.max(0, Math.min(Math.floor(c.minStat ?? 0), 200)),
+        maxStat: Math.max(0, Math.min(Math.ceil(c.maxStat ?? 200), 200)),
       }))
     : [];
 }

--- a/dim-api-types/LICENSE.md
+++ b/dim-api-types/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Destiny Item Manager
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dim-api-types/README.md
+++ b/dim-api-types/README.md
@@ -1,0 +1,3 @@
+# DIM API Types
+
+This package contains TypeScript types plus some defaults and enums that are useful when using the DIM API. Every request and response type is included, along with sensible defaults for Settings and LoadoutParameters.

--- a/dim-api-types/package.json
+++ b/dim-api-types/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@destinyitemmanager/dim-api-types",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "TypeScript types for the DIM API",
-  "main": "./index.cjs",
   "types": "./index.d.ts",
   "module": "./index.js",
   "type": "module",
   "sideEffects": false,
   "scripts": {},
+  "files": [
+    "index.cjs",
+    "index.d.ts",
+    "index.js",
+    "README.md",
+    "LICENSE.md",
+    "package.json"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/DestinyItemManager/dim-api.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,10 +25,6 @@ export default {
 
   output: [
     {
-      file: 'dim-api-types/' + pkg.main,
-      format: 'cjs',
-    },
-    {
       file: 'dim-api-types/' + pkg.module,
       format: 'es',
     },


### PR DESCRIPTION
NPM trusted publishing is a safer way to publish packages.

I don't think we need a CJS export anymore.